### PR TITLE
Feat/event type badge

### DIFF
--- a/frontend/components/tracking/EventCard.tsx
+++ b/frontend/components/tracking/EventCard.tsx
@@ -6,8 +6,7 @@ import { shortenPublicKey } from "@/lib/utils/format";
 
 import { EventTypeBadge, getEventTypeBadgeMeta } from "./EventTypeBadge";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function EventCard({ event, isFirst, isLast }: EventCardProps) {
+export function EventCard({ event, isLast }: Readonly<EventCardProps>) {
   const meta = getEventTypeBadgeMeta(event.event_type);
   const Icon = meta.icon;
 
@@ -38,7 +37,7 @@ export function EventCard({ event, isFirst, isLast }: EventCardProps) {
               </div>
 
               {event.note && (
-                <p className="mb-3 text-sm text-gray-700 break-words">{event.note}</p>
+                <p className="mb-3 text-sm text-gray-700 wrap-break-word">{event.note}</p>
               )}
 
               <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center text-xs text-gray-500">

--- a/frontend/components/tracking/EventTypeBadge.tsx
+++ b/frontend/components/tracking/EventTypeBadge.tsx
@@ -110,7 +110,7 @@ export function EventTypeBadge({
   label,
   className,
   ...props
-}: EventTypeBadgeProps) {
+}: Readonly<EventTypeBadgeProps>) {
   const meta = getEventTypeBadgeMeta(eventType);
 
   const Icon = meta.icon;

--- a/frontend/components/tracking/Timeline.tsx
+++ b/frontend/components/tracking/Timeline.tsx
@@ -9,7 +9,7 @@ interface TimelineProps {
   productId: string;
 }
 
-export function Timeline({ productId }: TimelineProps) {
+export function Timeline({ productId }: Readonly<TimelineProps>) {
   const [events, setEvents] = useState<TimelineEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -20,7 +20,7 @@ export function Timeline({ productId }: TimelineProps) {
       setError(null);
       const fetchedEvents = await fetchProductEvents(productId);
       // Sort by timestamp descending (newest first)
-      const sorted = fetchedEvents.sort((a, b) => b.timestamp - a.timestamp);
+      const sorted = fetchedEvents.toSorted((a, b) => b.timestamp - a.timestamp);
       setEvents(sorted);
     } catch (err) {
       setError(


### PR DESCRIPTION
# PR: Visual event type badges (icons, colors, sizes)
closes #36 

## Summary
Adds a reusable `EventTypeBadge` component for tracking events with:
- color-coded variants per event type
- `lucide-react` icon integration
- size variants: `sm`, `md`, `lg`
- text label (not color-only)

## Changes
- Added `frontend/components/tracking/EventTypeBadge.tsx`
- Updated `frontend/components/tracking/EventCard.tsx` to use `EventTypeBadge` and shared meta for the timeline marker

## Accessibility
- Badge always includes a **text label** alongside the icon
- Icon is marked `aria-hidden="true"` since the label is the accessible name

## Testing
- `npm run lint`
- `npm run build`

## Screenshots
N/A

## Checklist
- [x] All event types have unique colors
- [x] Icons display correctly
- [x] Sizes work (`sm`/`md`/`lg`)
- [x] Accessible (not color-only)
