### PR TITLE
feat(dashboard): add analytics with charts and activity feed

### DIFF
--- a/frontend/app/(app)/dashboard/page.tsx
+++ b/frontend/app/(app)/dashboard/page.tsx
@@ -1,7 +1,287 @@
+"use client";
+
+import * as React from "react";
+import {
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  Activity,
+  Boxes,
+  MapPinned,
+  RefreshCw,
+  TrendingUp,
+} from "lucide-react";
+
+import type { Product } from "@/lib/types/product";
+import type { TimelineEvent } from "@/lib/types/tracking";
+import { useWalletStore } from "@/lib/state/wallet.store";
+import { getProductsByOwner } from "@/lib/contract/products";
+import { fetchProductEvents } from "@/lib/contract/events";
+import { cn } from "@/lib/utils";
+
+import { StatCard } from "@/components/analytics/StatCard";
+import { EventsChart } from "@/components/analytics/EventsChart";
+import { ActivityFeed } from "@/components/analytics/ActivityFeed";
+
+type EventsByTypeDatum = { type: string; count: number };
+type ActivityDatum = { date: string; count: number };
+
+function formatDay(tsSeconds: number) {
+  const d = new Date(tsSeconds * 1000);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
 export default function DashboardPage() {
+  const { publicKey, status } = useWalletStore();
+
+  const [products, setProducts] = React.useState<Product[]>([]);
+  const [events, setEvents] = React.useState<TimelineEvent[]>([]);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [lastUpdatedAt, setLastUpdatedAt] = React.useState<number | null>(null);
+
+  const load = React.useCallback(async () => {
+    if (!publicKey) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const fetchedProducts = await getProductsByOwner(publicKey);
+      setProducts(fetchedProducts);
+
+      if (fetchedProducts.length === 0) {
+        setEvents([]);
+        setLastUpdatedAt(Date.now());
+        return;
+      }
+
+      const settled = await Promise.allSettled(
+        fetchedProducts.map((p) => fetchProductEvents(p.id))
+      );
+      const all = settled
+        .filter((r): r is PromiseFulfilledResult<TimelineEvent[]> => r.status === "fulfilled")
+        .flatMap((r) => r.value);
+
+      all.sort((a, b) => b.timestamp - a.timestamp);
+      setEvents(all);
+      setLastUpdatedAt(Date.now());
+
+      const rejectedCount = settled.filter((r) => r.status === "rejected").length;
+      if (rejectedCount > 0 && all.length === 0) {
+        setError(
+          "Events could not be loaded (contract not configured or unavailable). Showing product-only insights."
+        );
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load dashboard data");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [publicKey]);
+
+  React.useEffect(() => {
+    if (status !== "connected" || !publicKey) return;
+    load();
+  }, [status, publicKey, load]);
+
+  React.useEffect(() => {
+    if (status !== "connected" || !publicKey) return;
+    const id = setInterval(() => {
+      void load();
+    }, 30000);
+    return () => clearInterval(id);
+  }, [status, publicKey, load]);
+
+  const totalProducts = products.length;
+  const totalEvents = events.length;
+
+  const eventsByType: EventsByTypeDatum[] = React.useMemo(() => {
+    const map = new Map<string, number>();
+    for (const e of events) {
+      const t = e.event_type || "UNKNOWN";
+      map.set(t, (map.get(t) ?? 0) + 1);
+    }
+    return Array.from(map.entries()).map(([type, count]) => ({ type, count }));
+  }, [events]);
+
+  const activityOverTime: ActivityDatum[] = React.useMemo(() => {
+    const map = new Map<string, number>();
+    for (const e of events) {
+      const day = formatDay(e.timestamp);
+      map.set(day, (map.get(day) ?? 0) + 1);
+    }
+    return Array.from(map.entries())
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([date, count]) => ({ date, count }));
+  }, [events]);
+
+  const topOrigins = React.useMemo(() => {
+    const map = new Map<string, number>();
+    for (const p of products) {
+      const origin = p.origin?.location || "Unknown";
+      map.set(origin, (map.get(origin) ?? 0) + 1);
+    }
+    return Array.from(map.entries())
+      .map(([origin, count]) => ({ origin, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5);
+  }, [products]);
+
+  const recentEvents = React.useMemo(() => events.slice(0, 12), [events]);
+
+  const topOriginDescription = React.useMemo(() => {
+    if (isLoading) return undefined;
+    const first = topOrigins[0];
+    if (!first) return "No products yet.";
+    return `${first.count} product${first.count === 1 ? "" : "s"}`;
+  }, [isLoading, topOrigins]);
+
+  const canLoad = status === "connected" && Boolean(publicKey);
+
   return (
-    <main className="mx-auto max-w-3xl px-6 py-10">
-      <h1 className="text-2xl font-semibold">Analytics dashboard</h1>
+    <main className="mx-auto max-w-6xl px-6 py-10">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-zinc-900">Dashboard</h1>
+          <p className="mt-1 text-sm text-zinc-500">
+            Supply chain analytics for your registered products.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void load()}
+            disabled={!canLoad || isLoading}
+            className={cn(
+              "inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-semibold",
+              canLoad
+                ? "border-zinc-200 bg-white text-zinc-900 hover:bg-zinc-50"
+                : "border-zinc-200 bg-zinc-50 text-zinc-400",
+              isLoading && "opacity-50"
+            )}
+          >
+            <RefreshCw className={cn("h-4 w-4", isLoading && "animate-spin")} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {!canLoad ? (
+        <div className="mt-8 rounded-xl border border-zinc-200 bg-white p-8 shadow-sm">
+          <h2 className="text-lg font-semibold text-zinc-900">Connect your wallet</h2>
+          <p className="mt-1 text-sm text-zinc-600">
+            Connect a wallet to load products and events for analytics.
+          </p>
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="mt-6 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          label="Total products"
+          value={isLoading ? "—" : totalProducts}
+          description="Products currently visible to your wallet."
+          icon={<Boxes className="h-6 w-6" />}
+        />
+        <StatCard
+          label="Total events"
+          value={isLoading ? "—" : totalEvents}
+          description="All loaded tracking events."
+          icon={<Activity className="h-6 w-6" />}
+        />
+        <StatCard
+          label="Top origin"
+          value={isLoading ? "—" : (topOrigins[0]?.origin ?? "—")}
+          description={topOriginDescription}
+          icon={<MapPinned className="h-6 w-6" />}
+        />
+        <StatCard
+          label="Last updated"
+          value={lastUpdatedAt ? new Date(lastUpdatedAt).toLocaleTimeString() : "—"}
+          description="Auto-refreshes every 30s while connected."
+          icon={<TrendingUp className="h-6 w-6" />}
+        />
+      </div>
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <EventsChart data={eventsByType} />
+
+        <div className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
+          <div>
+            <h2 className="text-sm font-semibold text-zinc-900">Activity over time</h2>
+            <p className="mt-1 text-sm text-zinc-500">
+              Events grouped by day.
+            </p>
+          </div>
+          <div className="mt-4 h-72">
+            {isLoading ? (
+              <div className="h-full rounded-lg bg-zinc-100 animate-pulse" aria-hidden="true" />
+            ) : activityOverTime.length === 0 ? (
+              <div className="h-full rounded-lg border border-dashed border-zinc-200 bg-zinc-50 flex items-center justify-center text-sm text-zinc-500">
+                No activity yet.
+              </div>
+            ) : (
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={activityOverTime} margin={{ top: 10, right: 10, left: 0, bottom: 10 }}>
+                  <XAxis dataKey="date" tick={{ fontSize: 12 }} />
+                  <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
+                  <Tooltip />
+                  <Line type="monotone" dataKey="count" stroke="#2563eb" strokeWidth={2} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm lg:col-span-1">
+          <div>
+            <h2 className="text-sm font-semibold text-zinc-900">Top origins</h2>
+            <p className="mt-1 text-sm text-zinc-500">Most common product origins.</p>
+          </div>
+
+          <div className="mt-4">
+            {isLoading ? (
+              <div className="space-y-3" aria-hidden="true">
+                {Array.from({ length: 5 }, (_, i) => (
+                  <div key={i} className="h-10 rounded-lg bg-zinc-100 animate-pulse" />
+                ))}
+              </div>
+            ) : topOrigins.length === 0 ? (
+              <div className="rounded-lg border border-dashed border-zinc-200 bg-zinc-50 p-6 text-sm text-zinc-500">
+                No products yet.
+              </div>
+            ) : (
+              <ul className="space-y-3">
+                {topOrigins.map((o) => (
+                  <li key={o.origin} className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium text-zinc-900 truncate">{o.origin}</span>
+                    <span className="text-sm text-zinc-600">{o.count}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        <ActivityFeed events={recentEvents} isLoading={isLoading} className="lg:col-span-2" />
+      </div>
     </main>
   );
 }

--- a/frontend/components/analytics/ActivityFeed.tsx
+++ b/frontend/components/analytics/ActivityFeed.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+
+import type { TimelineEvent } from "@/lib/types/tracking";
+import { formatEventTimestamp } from "@/lib/contract/events";
+import { cn } from "@/lib/utils";
+
+export interface ActivityFeedProps {
+  title?: string;
+  events: TimelineEvent[];
+  isLoading?: boolean;
+  className?: string;
+}
+
+export function ActivityFeed({
+  title = "Recent activity",
+  events,
+  isLoading,
+  className,
+}: Readonly<ActivityFeedProps>) {
+  return (
+    <div className={cn("rounded-xl border border-zinc-200 bg-white p-5 shadow-sm", className)}>
+      <div>
+        <h2 className="text-sm font-semibold text-zinc-900">{title}</h2>
+        <p className="mt-1 text-sm text-zinc-500">Latest events across your products.</p>
+      </div>
+
+      <div className="mt-4">
+        {isLoading ? (
+          <div className="space-y-3" aria-hidden="true">
+            {Array.from({ length: 6 }, (_, i) => (
+              <div key={i} className="h-12 rounded-lg bg-zinc-100 animate-pulse" />
+            ))}
+          </div>
+        ) : events.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-zinc-200 bg-zinc-50 p-6 text-sm text-zinc-500">
+            No recent events.
+          </div>
+        ) : (
+          <ul className="divide-y divide-zinc-100">
+            {events.map((e) => (
+              <li key={e.event_id} className="py-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-zinc-900 truncate">
+                      {e.event_type}
+                      <span className="text-zinc-400 font-normal"> · </span>
+                      <span className="text-zinc-600 font-medium">{e.product_id}</span>
+                    </p>
+                    {e.note ? (
+                      <p className="mt-0.5 text-sm text-zinc-600 wrap-break-word">
+                        {e.note}
+                      </p>
+                    ) : null}
+                  </div>
+                  <p className="shrink-0 text-xs text-zinc-500 whitespace-nowrap">
+                    {formatEventTimestamp(e.timestamp)}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/analytics/EventsChart.tsx
+++ b/frontend/components/analytics/EventsChart.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import * as React from "react";
+import {
+  Bar,
+  BarChart,
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { cn } from "@/lib/utils";
+
+type EventsByTypeDatum = {
+  type: string;
+  count: number;
+};
+
+const DEFAULT_COLORS = [
+  "#16a34a", // green
+  "#2563eb", // blue
+  "#7c3aed", // purple
+  "#ea580c", // orange
+  "#0891b2", // cyan
+  "#ca8a04", // yellow
+  "#4f46e5", // indigo
+  "#db2777", // pink
+  "#64748b", // slate
+];
+
+export interface EventsChartProps {
+  title?: string;
+  data: EventsByTypeDatum[];
+  className?: string;
+}
+
+export function EventsChart({
+  title = "Events by type",
+  data,
+  className,
+}: Readonly<EventsChartProps>) {
+  const [mode, setMode] = React.useState<"pie" | "bar">("pie");
+
+  const sorted = React.useMemo(() => {
+    return [...data].sort((a, b) => b.count - a.count);
+  }, [data]);
+
+  const empty = sorted.length === 0;
+
+  return (
+    <div className={cn("rounded-xl border border-zinc-200 bg-white p-5 shadow-sm", className)}>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-zinc-900">{title}</h2>
+          <p className="mt-1 text-sm text-zinc-500">Distribution of tracking events.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setMode("pie")}
+            className={cn(
+              "rounded-lg border px-3 py-1.5 text-xs font-semibold",
+              mode === "pie" ? "bg-zinc-900 text-white border-zinc-900" : "bg-white text-zinc-700 border-zinc-200 hover:bg-zinc-50"
+            )}
+          >
+            Pie
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode("bar")}
+            className={cn(
+              "rounded-lg border px-3 py-1.5 text-xs font-semibold",
+              mode === "bar" ? "bg-zinc-900 text-white border-zinc-900" : "bg-white text-zinc-700 border-zinc-200 hover:bg-zinc-50"
+            )}
+          >
+            Bar
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-4 h-72">
+        {empty ? (
+          <div className="h-full rounded-lg border border-dashed border-zinc-200 bg-zinc-50 flex items-center justify-center text-sm text-zinc-500">
+            No event data yet.
+          </div>
+        ) : mode === "pie" ? (
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Tooltip
+                formatter={(value: unknown, name: unknown) => [value as number, name as string]}
+              />
+              <Pie
+                data={sorted}
+                dataKey="count"
+                nameKey="type"
+                innerRadius={60}
+                outerRadius={100}
+                paddingAngle={2}
+                isAnimationActive
+              >
+                {sorted.map((entry, idx) => (
+                  <Cell
+                    key={`${entry.type}-${idx}`}
+                    fill={DEFAULT_COLORS[idx % DEFAULT_COLORS.length]}
+                  />
+                ))}
+              </Pie>
+            </PieChart>
+          </ResponsiveContainer>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={sorted} margin={{ top: 10, right: 10, left: 0, bottom: 10 }}>
+              <XAxis dataKey="type" tick={{ fontSize: 12 }} />
+              <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
+              <Tooltip />
+              <Bar dataKey="count" radius={[6, 6, 0, 0]}>
+                {sorted.map((entry, idx) => (
+                  <Cell
+                    key={`${entry.type}-${idx}`}
+                    fill={DEFAULT_COLORS[idx % DEFAULT_COLORS.length]}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/analytics/StatCard.tsx
+++ b/frontend/components/analytics/StatCard.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface StatCardProps {
+  label: string;
+  value: React.ReactNode;
+  description?: string;
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+export function StatCard({
+  label,
+  value,
+  description,
+  icon,
+  className,
+}: Readonly<StatCardProps>) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-zinc-200 bg-white p-5 shadow-sm",
+        className
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-zinc-600">{label}</p>
+          <div className="mt-1 text-2xl font-semibold text-zinc-900">
+            {value}
+          </div>
+          {description ? (
+            <p className="mt-1 text-sm text-zinc-500">{description}</p>
+          ) : null}
+        </div>
+        {icon ? (
+          <div className="shrink-0 text-zinc-400" aria-hidden="true">
+            {icon}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
Implements the dashboard analytics page to replace the placeholder dashboard.

Adds product/event insights, charts, top origins, and a recent activity feed with loading + empty states and a manual refresh + auto-refresh while connected.

## Related Issue
Closes #28 

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

## Testing
- [x] Frontend `npm run build`
- [x] Frontend `npm run lint` (warnings only; no errors)

## Screenshots
N/A

## Checklist
- [x] Code follows style guide
- [x] Self-reviewed
- [ ] Docs updated
- [ ] Tests added
