### PR TITLE
Extract storage utilities into StorageContract (#76)

### DIFF
--- a/smart-contract/contracts/src/lib.rs
+++ b/smart-contract/contracts/src/lib.rs
@@ -5,6 +5,7 @@ mod contract;
 mod product_registry;
 mod types;
 mod storage;
+mod storage_contract;
 mod error;
 mod validation;
 mod authorization;

--- a/smart-contract/contracts/src/storage.rs
+++ b/smart-contract/contracts/src/storage.rs
@@ -1,48 +1,38 @@
 use soroban_sdk::{Address, Env, String, Symbol, Vec};
 
-use crate::types::{DataKey, Product, TrackingEvent};
+use crate::storage_contract::StorageContract;
+use crate::types::{Product, TrackingEvent};
 
 pub fn get_auth_contract(env: &Env) -> Option<Address> {
-    env.storage().persistent().get(&DataKey::AuthContract)
+    StorageContract::get_auth_contract(env)
 }
 
 pub fn set_auth_contract(env: &Env, address: &Address) {
-    env.storage().persistent().set(&DataKey::AuthContract, address);
+    StorageContract::set_auth_contract(env, address)
 }
 
 // ─── Product ────────────────────────────────────────────────────────────────
 
 pub fn has_product(env: &Env, product_id: &String) -> bool {
-    env.storage()
-        .persistent()
-        .has(&DataKey::Product(product_id.clone()))
+    StorageContract::has_product(env, product_id)
 }
 
 pub fn put_product(env: &Env, product: &Product) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::Product(product.id.clone()), product);
+    StorageContract::put_product(env, product)
 }
 
 pub fn get_product(env: &Env, product_id: &String) -> Option<Product> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::Product(product_id.clone()))
+    StorageContract::get_product(env, product_id)
 }
 
 // ─── Event IDs per product ───────────────────────────────────────────────────
 
 pub fn put_product_event_ids(env: &Env, product_id: &String, ids: &Vec<u64>) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::ProductEventIds(product_id.clone()), ids);
+    StorageContract::put_product_event_ids(env, product_id, ids)
 }
 
 pub fn get_product_event_ids(env: &Env, product_id: &String) -> Vec<u64> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::ProductEventIds(product_id.clone()))
-        .unwrap_or(Vec::new(env))
+    StorageContract::get_product_event_ids(env, product_id)
 }
 
 pub fn get_product_event_ids_paginated(
@@ -51,46 +41,21 @@ pub fn get_product_event_ids_paginated(
     offset: u64,
     limit: u64,
 ) -> Vec<u64> {
-    let all_ids = get_product_event_ids(env, product_id);
-    let total = all_ids.len() as u64;
-
-    let mut result = Vec::new(env);
-
-    if offset >= total {
-        return result;
-    }
-
-    let end = ((offset + limit) as u32).min(all_ids.len());
-    let start = offset as u32;
-
-    for i in start..end {
-        result.push_back(all_ids.get_unchecked(i));
-    }
-
-    result
+    StorageContract::get_product_event_ids_paginated(env, product_id, offset, limit)
 }
 
 // ─── Events ─────────────────────────────────────────────────────────────────
 
 pub fn put_event(env: &Env, event: &TrackingEvent) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::Event(event.event_id), event);
+    StorageContract::put_event(env, event)
 }
 
 pub fn get_event(env: &Env, event_id: u64) -> Option<TrackingEvent> {
-    env.storage().persistent().get(&DataKey::Event(event_id))
+    StorageContract::get_event(env, event_id)
 }
 
 pub fn next_event_id(env: &Env) -> u64 {
-    let mut seq: u64 = env
-        .storage()
-        .persistent()
-        .get(&DataKey::EventSeq)
-        .unwrap_or(0);
-    seq += 1;
-    env.storage().persistent().set(&DataKey::EventSeq, &seq);
-    seq
+    StorageContract::next_event_id(env)
 }
 
 // ─── Event type index ────────────────────────────────────────────────────────
@@ -101,13 +66,7 @@ pub fn index_event_by_type(
     event_type: &Symbol,
     event_id: u64,
 ) {
-    let count_key = DataKey::EventTypeCount(product_id.clone(), event_type.clone());
-    let mut count: u64 = env.storage().persistent().get(&count_key).unwrap_or(0);
-    count += 1;
-    env.storage().persistent().set(&count_key, &count);
-
-    let index_key = DataKey::EventTypeIndex(product_id.clone(), event_type.clone(), count);
-    env.storage().persistent().set(&index_key, &event_id);
+    StorageContract::index_event_by_type(env, product_id, event_type, event_id)
 }
 
 pub fn get_event_ids_by_type(
@@ -117,104 +76,59 @@ pub fn get_event_ids_by_type(
     offset: u64,
     limit: u64,
 ) -> Vec<u64> {
-    let count_key = DataKey::EventTypeCount(product_id.clone(), event_type.clone());
-    let total: u64 = env.storage().persistent().get(&count_key).unwrap_or(0);
-
-    let mut result = Vec::new(env);
-
-    if offset >= total {
-        return result;
-    }
-
-    let start = offset + 1;
-    let end = (start + limit).min(total + 1);
-
-    for i in start..end {
-        let index_key = DataKey::EventTypeIndex(product_id.clone(), event_type.clone(), i);
-        if let Some(event_id) = env
-            .storage()
-            .persistent()
-            .get::<DataKey, u64>(&index_key)
-        {
-            result.push_back(event_id);
-        }
-    }
-
-    result
+    StorageContract::get_event_ids_by_type(env, product_id, event_type, offset, limit)
 }
 
 pub fn get_event_count_by_type(env: &Env, product_id: &String, event_type: &Symbol) -> u64 {
-    let count_key = DataKey::EventTypeCount(product_id.clone(), event_type.clone());
-    env.storage().persistent().get(&count_key).unwrap_or(0)
+    StorageContract::get_event_count_by_type(env, product_id, event_type)
 }
 
 // ─── Authorization ───────────────────────────────────────────────────────────
 
 pub fn set_auth(env: &Env, product_id: &String, actor: &Address, value: bool) {
-    if value {
-        env.storage()
-            .persistent()
-            .set(&DataKey::Auth(product_id.clone(), actor.clone()), &true);
-    } else {
-        env.storage()
-            .persistent()
-            .remove(&DataKey::Auth(product_id.clone(), actor.clone()));
-    }
+    StorageContract::set_auth(env, product_id, actor, value)
 }
 
 pub fn is_authorized(env: &Env, product_id: &String, actor: &Address) -> bool {
-    env.storage()
-        .persistent()
-        .get(&DataKey::Auth(product_id.clone(), actor.clone()))
-        .unwrap_or(false)
+    StorageContract::is_authorized(env, product_id, actor)
 }
 
 // ─── Global Management ───────────────────────────────────────────────────────
 
 pub fn has_admin(env: &Env) -> bool {
-    env.storage().persistent().has(&DataKey::Admin)
+    StorageContract::has_admin(env)
 }
 
 pub fn get_admin(env: &Env) -> Option<Address> {
-    env.storage().persistent().get(&DataKey::Admin)
+    StorageContract::get_admin(env)
 }
 
 pub fn set_admin(env: &Env, admin: &Address) {
-    env.storage().persistent().set(&DataKey::Admin, admin);
+    StorageContract::set_admin(env, admin)
 }
 
 pub fn is_paused(env: &Env) -> bool {
-    env.storage().persistent().get(&DataKey::Paused).unwrap_or(false)
+    StorageContract::is_paused(env)
 }
 
 pub fn set_paused(env: &Env, paused: bool) {
-    env.storage().persistent().set(&DataKey::Paused, &paused);
+    StorageContract::set_paused(env, paused)
 }
 
 // ─── Global counters ─────────────────────────────────────────────────────────
 
 pub fn get_total_products(env: &Env) -> u64 {
-    env.storage()
-        .instance()
-        .get(&DataKey::TotalProducts)
-        .unwrap_or(0)
+    StorageContract::get_total_products(env)
 }
 
 pub fn set_total_products(env: &Env, count: u64) {
-    env.storage()
-        .instance()
-        .set(&DataKey::TotalProducts, &count);
+    StorageContract::set_total_products(env, count)
 }
 
 pub fn get_active_products(env: &Env) -> u64 {
-    env.storage()
-        .instance()
-        .get(&DataKey::ActiveProducts)
-        .unwrap_or(0)
+    StorageContract::get_active_products(env)
 }
 
 pub fn set_active_products(env: &Env, count: u64) {
-    env.storage()
-        .instance()
-        .set(&DataKey::ActiveProducts, &count);
+    StorageContract::set_active_products(env, count)
 }

--- a/smart-contract/contracts/src/storage_contract.rs
+++ b/smart-contract/contracts/src/storage_contract.rs
@@ -1,0 +1,366 @@
+use soroban_sdk::{Address, Env, String, Symbol, Vec};
+
+use crate::types::{DataKey, Product, TrackingEvent};
+
+pub struct StorageContract;
+
+impl StorageContract {
+    pub fn auth_contract_key() -> DataKey {
+        DataKey::AuthContract
+    }
+
+    pub fn product_key(product_id: &String) -> DataKey {
+        DataKey::Product(product_id.clone())
+    }
+
+    pub fn product_event_ids_key(product_id: &String) -> DataKey {
+        DataKey::ProductEventIds(product_id.clone())
+    }
+
+    pub fn event_key(event_id: u64) -> DataKey {
+        DataKey::Event(event_id)
+    }
+
+    pub fn event_seq_key() -> DataKey {
+        DataKey::EventSeq
+    }
+
+    pub fn event_type_count_key(product_id: &String, event_type: &Symbol) -> DataKey {
+        DataKey::EventTypeCount(product_id.clone(), event_type.clone())
+    }
+
+    pub fn event_type_index_key(product_id: &String, event_type: &Symbol, index: u64) -> DataKey {
+        DataKey::EventTypeIndex(product_id.clone(), event_type.clone(), index)
+    }
+
+    pub fn auth_key(product_id: &String, actor: &Address) -> DataKey {
+        DataKey::Auth(product_id.clone(), actor.clone())
+    }
+
+    pub fn admin_key() -> DataKey {
+        DataKey::Admin
+    }
+
+    pub fn paused_key() -> DataKey {
+        DataKey::Paused
+    }
+
+    pub fn total_products_key() -> DataKey {
+        DataKey::TotalProducts
+    }
+
+    pub fn active_products_key() -> DataKey {
+        DataKey::ActiveProducts
+    }
+
+    pub fn get_auth_contract(env: &Env) -> Option<Address> {
+        env.storage().persistent().get(&Self::auth_contract_key())
+    }
+
+    pub fn set_auth_contract(env: &Env, address: &Address) {
+        env.storage()
+            .persistent()
+            .set(&Self::auth_contract_key(), address);
+    }
+
+    pub fn has_product(env: &Env, product_id: &String) -> bool {
+        env.storage().persistent().has(&Self::product_key(product_id))
+    }
+
+    pub fn put_product(env: &Env, product: &Product) {
+        env.storage()
+            .persistent()
+            .set(&Self::product_key(&product.id), product);
+    }
+
+    pub fn get_product(env: &Env, product_id: &String) -> Option<Product> {
+        env.storage()
+            .persistent()
+            .get(&Self::product_key(product_id))
+    }
+
+    pub fn put_product_event_ids(env: &Env, product_id: &String, ids: &Vec<u64>) {
+        env.storage()
+            .persistent()
+            .set(&Self::product_event_ids_key(product_id), ids);
+    }
+
+    pub fn get_product_event_ids(env: &Env, product_id: &String) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&Self::product_event_ids_key(product_id))
+            .unwrap_or(Vec::new(env))
+    }
+
+    pub fn get_product_event_ids_paginated(
+        env: &Env,
+        product_id: &String,
+        offset: u64,
+        limit: u64,
+    ) -> Vec<u64> {
+        let all_ids = Self::get_product_event_ids(env, product_id);
+        let total = all_ids.len() as u64;
+
+        let mut result = Vec::new(env);
+
+        if offset >= total {
+            return result;
+        }
+
+        let end = ((offset + limit) as u32).min(all_ids.len());
+        let start = offset as u32;
+
+        for i in start..end {
+            result.push_back(all_ids.get_unchecked(i));
+        }
+
+        result
+    }
+
+    pub fn put_event(env: &Env, event: &TrackingEvent) {
+        env.storage()
+            .persistent()
+            .set(&Self::event_key(event.event_id), event);
+    }
+
+    pub fn get_event(env: &Env, event_id: u64) -> Option<TrackingEvent> {
+        env.storage().persistent().get(&Self::event_key(event_id))
+    }
+
+    pub fn next_event_id(env: &Env) -> u64 {
+        let mut seq: u64 = env
+            .storage()
+            .persistent()
+            .get(&Self::event_seq_key())
+            .unwrap_or(0);
+        seq += 1;
+        env.storage()
+            .persistent()
+            .set(&Self::event_seq_key(), &seq);
+        seq
+    }
+
+    pub fn index_event_by_type(env: &Env, product_id: &String, event_type: &Symbol, event_id: u64) {
+        let count_key = Self::event_type_count_key(product_id, event_type);
+        let mut count: u64 = env.storage().persistent().get(&count_key).unwrap_or(0);
+        count += 1;
+        env.storage().persistent().set(&count_key, &count);
+
+        let index_key = Self::event_type_index_key(product_id, event_type, count);
+        env.storage().persistent().set(&index_key, &event_id);
+    }
+
+    pub fn get_event_ids_by_type(
+        env: &Env,
+        product_id: &String,
+        event_type: &Symbol,
+        offset: u64,
+        limit: u64,
+    ) -> Vec<u64> {
+        let count_key = Self::event_type_count_key(product_id, event_type);
+        let total: u64 = env.storage().persistent().get(&count_key).unwrap_or(0);
+
+        let mut result = Vec::new(env);
+
+        if offset >= total {
+            return result;
+        }
+
+        let start = offset + 1;
+        let end = (start + limit).min(total + 1);
+
+        for i in start..end {
+            let index_key = Self::event_type_index_key(product_id, event_type, i);
+            if let Some(event_id) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, u64>(&index_key)
+            {
+                result.push_back(event_id);
+            }
+        }
+
+        result
+    }
+
+    pub fn get_event_count_by_type(env: &Env, product_id: &String, event_type: &Symbol) -> u64 {
+        let count_key = Self::event_type_count_key(product_id, event_type);
+        env.storage().persistent().get(&count_key).unwrap_or(0)
+    }
+
+    pub fn set_auth(env: &Env, product_id: &String, actor: &Address, value: bool) {
+        if value {
+            env.storage()
+                .persistent()
+                .set(&Self::auth_key(product_id, actor), &true);
+        } else {
+            env.storage()
+                .persistent()
+                .remove(&Self::auth_key(product_id, actor));
+        }
+    }
+
+    pub fn is_authorized(env: &Env, product_id: &String, actor: &Address) -> bool {
+        env.storage()
+            .persistent()
+            .get(&Self::auth_key(product_id, actor))
+            .unwrap_or(false)
+    }
+
+    pub fn has_admin(env: &Env) -> bool {
+        env.storage().persistent().has(&Self::admin_key())
+    }
+
+    pub fn get_admin(env: &Env) -> Option<Address> {
+        env.storage().persistent().get(&Self::admin_key())
+    }
+
+    pub fn set_admin(env: &Env, admin: &Address) {
+        env.storage().persistent().set(&Self::admin_key(), admin);
+    }
+
+    pub fn is_paused(env: &Env) -> bool {
+        env.storage().persistent().get(&Self::paused_key()).unwrap_or(false)
+    }
+
+    pub fn set_paused(env: &Env, paused: bool) {
+        env.storage().persistent().set(&Self::paused_key(), &paused);
+    }
+
+    pub fn get_total_products(env: &Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&Self::total_products_key())
+            .unwrap_or(0)
+    }
+
+    pub fn set_total_products(env: &Env, count: u64) {
+        env.storage()
+            .instance()
+            .set(&Self::total_products_key(), &count);
+    }
+
+    pub fn get_active_products(env: &Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&Self::active_products_key())
+            .unwrap_or(0)
+    }
+
+    pub fn set_active_products(env: &Env, count: u64) {
+        env.storage()
+            .instance()
+            .set(&Self::active_products_key(), &count);
+    }
+}
+
+#[cfg(test)]
+mod test_storage_contract {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, BytesN, Map};
+
+    use crate::contract::ChainLogisticsContract;
+    use crate::types::Origin;
+
+    #[test]
+    fn test_product_put_get() {
+        let env = Env::default();
+        let owner = Address::generate(&env);
+        let contract_id = env.register_contract(None, ChainLogisticsContract);
+
+        let product = Product {
+            id: String::from_str(&env, "P1"),
+            name: String::from_str(&env, "Name"),
+            description: String::from_str(&env, "Desc"),
+            origin: Origin {
+                location: String::from_str(&env, "Loc"),
+            },
+            owner: owner.clone(),
+            created_at: 0,
+            active: true,
+            category: String::from_str(&env, "Cat"),
+            tags: Vec::new(&env),
+            certifications: Vec::new(&env),
+            media_hashes: Vec::new(&env),
+            custom: Map::new(&env),
+            deactivation_info: Vec::new(&env),
+        };
+
+        env.as_contract(&contract_id, || {
+            assert!(!StorageContract::has_product(&env, &product.id));
+            StorageContract::put_product(&env, &product);
+            assert!(StorageContract::has_product(&env, &product.id));
+            assert!(StorageContract::get_product(&env, &product.id).is_some());
+        });
+    }
+
+    #[test]
+    fn test_event_id_sequence_increments() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, ChainLogisticsContract);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(StorageContract::next_event_id(&env), 1);
+            assert_eq!(StorageContract::next_event_id(&env), 2);
+        });
+    }
+
+    #[test]
+    fn test_authorization_mapping() {
+        let env = Env::default();
+        let actor = Address::generate(&env);
+        let product_id = String::from_str(&env, "P1");
+
+        let contract_id = env.register_contract(None, ChainLogisticsContract);
+
+        env.as_contract(&contract_id, || {
+            assert!(!StorageContract::is_authorized(&env, &product_id, &actor));
+            StorageContract::set_auth(&env, &product_id, &actor, true);
+            assert!(StorageContract::is_authorized(&env, &product_id, &actor));
+            StorageContract::set_auth(&env, &product_id, &actor, false);
+            assert!(!StorageContract::is_authorized(&env, &product_id, &actor));
+        });
+    }
+
+    #[test]
+    fn test_counters_roundtrip() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, ChainLogisticsContract);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(StorageContract::get_total_products(&env), 0);
+            assert_eq!(StorageContract::get_active_products(&env), 0);
+
+            StorageContract::set_total_products(&env, 10);
+            StorageContract::set_active_products(&env, 7);
+
+            assert_eq!(StorageContract::get_total_products(&env), 10);
+            assert_eq!(StorageContract::get_active_products(&env), 7);
+        });
+    }
+
+    #[test]
+    fn test_event_put_get() {
+        let env = Env::default();
+        let owner = Address::generate(&env);
+        let contract_id = env.register_contract(None, ChainLogisticsContract);
+
+        let event = TrackingEvent {
+            event_id: 1,
+            product_id: String::from_str(&env, "P1"),
+            event_type: Symbol::new(&env, "created"),
+            location: String::from_str(&env, "Loc"),
+            data_hash: BytesN::from_array(&env, &[0; 32]),
+            note: String::from_str(&env, "Note"),
+            metadata: Map::new(&env),
+            actor: owner,
+            timestamp: 0,
+        };
+
+        env.as_contract(&contract_id, || {
+            assert!(StorageContract::get_event(&env, 1).is_none());
+            StorageContract::put_event(&env, &event);
+            assert!(StorageContract::get_event(&env, 1).is_some());
+        });
+    }
+}

--- a/smart-contract/contracts/test_snapshots/storage_contract/test_storage_contract/test_authorization_mapping.1.json
+++ b/smart-contract/contracts/test_snapshots/storage_contract/test_storage_contract/test_authorization_mapping.1.json
@@ -1,0 +1,75 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 20,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/smart-contract/contracts/test_snapshots/storage_contract/test_storage_contract/test_counters_roundtrip.1.json
+++ b/smart-contract/contracts/test_snapshots/storage_contract/test_storage_contract/test_counters_roundtrip.1.json
@@ -1,0 +1,100 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 20,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ActiveProducts"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 7
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TotalProducts"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 10
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/smart-contract/contracts/test_snapshots/storage_contract/test_storage_contract/test_event_id_sequence_increments.1.json
+++ b/smart-contract/contracts/test_snapshots/storage_contract/test_storage_contract/test_event_id_sequence_increments.1.json
@@ -1,0 +1,114 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 20,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "EventSeq"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "EventSeq"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u64": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/smart-contract/contracts/test_snapshots/storage_contract/test_storage_contract/test_event_put_get.1.json
+++ b/smart-contract/contracts/test_snapshots/storage_contract/test_storage_contract/test_event_put_get.1.json
@@ -1,0 +1,193 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 20,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Event"
+                },
+                {
+                  "u64": 1
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Event"
+                    },
+                    {
+                      "u64": 1
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "actor"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "data_hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "event_id"
+                      },
+                      "val": {
+                        "u64": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "event_type"
+                      },
+                      "val": {
+                        "symbol": "created"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "location"
+                      },
+                      "val": {
+                        "string": "Loc"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "map": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "note"
+                      },
+                      "val": {
+                        "string": "Note"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "product_id"
+                      },
+                      "val": {
+                        "string": "P1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "timestamp"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/smart-contract/contracts/test_snapshots/storage_contract/test_storage_contract/test_product_put_get.1.json
+++ b/smart-contract/contracts/test_snapshots/storage_contract/test_storage_contract/test_product_put_get.1.json
@@ -1,0 +1,234 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 20,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Product"
+                },
+                {
+                  "string": "P1"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Product"
+                    },
+                    {
+                      "string": "P1"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "active"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "category"
+                      },
+                      "val": {
+                        "string": "Cat"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "certifications"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "created_at"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "custom"
+                      },
+                      "val": {
+                        "map": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deactivation_info"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": "Desc"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "id"
+                      },
+                      "val": {
+                        "string": "P1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "media_hashes"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": "Name"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "origin"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "location"
+                            },
+                            "val": {
+                              "string": "Loc"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "tags"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
# Extract storage utilities into StorageContract (closes #76)

Closes #76 

## Summary
This PR centralizes storage operations into a dedicated [StorageContract](cci:2://file:///Users/mac/Documents/DripsOS/ChainLogistics/smart-contract/contracts/src/storage_contract.rs:4:0-4:27) to make persistence logic authoritative, reusable, and consistent across the smart-contract crate.

## Changes
- Added [storage_contract.rs](cci:7://file:///Users/mac/Documents/DripsOS/ChainLogistics/smart-contract/contracts/src/storage_contract.rs:0:0-0:0) implementing centralized storage operations:
  - Product storage (has/get/put)
  - Event storage (get/put)
  - Event ID sequencing ([next_event_id](cci:1://file:///Users/mac/Documents/DripsOS/ChainLogistics/smart-contract/contracts/src/storage.rs:56:0-58:1))
  - Event type indexing + lookup helpers
  - Authorization mappings (set/is-authorized)
  - Global admin/paused flags
  - Global counters (total/active products)
  - Storage-key generation utilities (wrapping `DataKey`)
- Refactored [storage.rs](cci:7://file:///Users/mac/Documents/DripsOS/ChainLogistics/smart-contract/contracts/src/storage.rs:0:0-0:0) to delegate to [StorageContract](cci:2://file:///Users/mac/Documents/DripsOS/ChainLogistics/smart-contract/contracts/src/storage_contract.rs:4:0-4:27) so existing call sites remain unchanged.
- Updated [lib.rs](cci:7://file:///Users/mac/Documents/DripsOS/ChainLogistics/smart-contract/contracts/src/lib.rs:0:0-0:0) to include the new module.
- Added unit tests for core storage operations and snapshots.

## Testing
- `cargo test`

## Notes
[storage.rs](cci:7://file:///Users/mac/Documents/DripsOS/ChainLogistics/smart-contract/contracts/src/storage.rs:0:0-0:0) remains as a compatibility shim; the authoritative logic is now in [StorageContract](cci:2://file:///Users/mac/Documents/DripsOS/ChainLogistics/smart-contract/contracts/src/storage_contract.rs:4:0-4:27).