### PR TITLE
fix: resolve dependency version mismatch

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -23,7 +23,6 @@ anyhow = "1.0"
 config = "0.14"
 async-trait = "0.1"
 # Stellar/Soroban dependencies
-stellar-sdk = "0.24"
 soroban-sdk = "21.0"
 # OpenAPI documentation
 utoipa = { version = "4.0", features = ["axum_extras"] }


### PR DESCRIPTION
## Summary

- Remove invalid stellar-sdk dependency from backend/Cargo.toml
- stellar-sdk = "0.24" doesn't exist in crates.io
- Dependency was unused in codebase anyway
- Fixes critical backend compilation failure

Closes #146

