### PR TITLE
feat(audit-trail): privacy-preserving ring signatures (#413)

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -320,6 +320,27 @@ isort src tests
 mypy src
 ```
 
+## Ring signatures (privacy-preserving audit trail)
+
+Sign audit attestations anonymously as one member of a ring of auditors
+(BLS12-381). The module is pure-stdlib (no extra dependencies) and produces
+signatures that verify on-chain via the `AuditTrailContract` /
+`RingSignatureVerifier` Soroban contracts unchanged.
+
+```python
+from chainlogistics_sdk.ring_signature import KeyPair, sign, verify
+
+auditors = [KeyPair.generate() for _ in range(8)]
+ring = [k.public_key() for k in auditors]
+
+msg = b"custody: warehouse-A -> truck-7"
+sig = sign(ring, 3, auditors[3], msg)   # auditor #3 signs anonymously
+assert verify(ring, msg, sig)
+```
+
+See `smart-contract/RING_SIGNATURE.md` for the full scheme, gas costs and
+linkability analysis.
+
 ## License
 
 MIT License - see LICENSE file for details.

--- a/sdk/python/src/chainlogistics_sdk/__init__.py
+++ b/sdk/python/src/chainlogistics_sdk/__init__.py
@@ -32,6 +32,14 @@ from .models import (
     EventListQuery,
     PaginationMeta,
 )
+from . import ring_signature
+from .ring_signature import (
+    KeyPair,
+    RingSignature,
+    sign,
+    verify,
+    aggregate_ring,
+)
 
 __version__ = "1.0.0"
 __author__ = "ChainLogistics Team"
@@ -66,4 +74,11 @@ __all__ = [
     "ProductListQuery",
     "EventListQuery",
     "PaginationMeta",
+    # Ring signatures (privacy-preserving audit trail)
+    "ring_signature",
+    "KeyPair",
+    "RingSignature",
+    "sign",
+    "verify",
+    "aggregate_ring",
 ]

--- a/sdk/python/src/chainlogistics_sdk/ring_signature.py
+++ b/sdk/python/src/chainlogistics_sdk/ring_signature.py
@@ -1,0 +1,285 @@
+"""AOS/SAG ring signatures over BLS12-381 G1 — the off-chain counterpart to the
+``RingSignatureVerifier`` / ``AuditTrailContract`` Soroban contracts. An auditor
+signs a statement as an anonymous member of a ring; the signature verifies
+on-chain unchanged (cross-checked against a contract-produced vector in the
+tests).
+
+The G1 arithmetic (no pairings) is implemented here over the standard library
+so the SDK stays dependency-free. It is **not** constant-time — fine for signing
+attestations, but do not reuse it for high-frequency secret-key operations under
+a timing adversary.
+
+Wire format (must match the contract): public key = uncompressed G1 ``x ‖ y``
+(48 bytes each, big-endian) = 96 bytes; each scalar (``c0``, ``s_i``) = 32-byte
+big-endian canonical ``F_r``; challenge = ``SHA-256(...)`` as a big-endian
+integer mod ``r``.
+
+Example::
+
+    from chainlogistics_sdk.ring_signature import KeyPair, sign, verify
+
+    auditors = [KeyPair.generate() for _ in range(3)]
+    ring = [k.public_key() for k in auditors]
+    sig = sign(ring, 1, auditors[1], b"custody: warehouse-A -> truck-7")
+    assert verify(ring, b"custody: warehouse-A -> truck-7", sig)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+# ─── BLS12-381 parameters ───────────────────────────────────────────────────
+
+# Base field modulus p.
+P = 0x1A0111EA397FE69A4B1BA7B6434BACD764774B84F38512BF6730D2A0F6B0F6241EABFFFEB153FFFFB9FEFFFFFFFFAAAB
+# Scalar field order r.
+R = 0x73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001
+# Curve: y^2 = x^3 + B over F_p.
+B = 4
+# Standard G1 generator (x, y).
+GX = 0x17F1D3A73197D7942695638C4FA9AC0FC3688C4F9774B905A14E3A3F171BAC586C55E83FF97A1AEFFB3AF00ADB22C6BB
+GY = 0x08B3F481E3AAA0F1A09E30ED741D8AE4FCF5E095D5D00AF600DB18CB2C04B3EDD03CC744A2888AE40CAA232946C5E7E1
+
+# Must match the Soroban contract byte-for-byte.
+_DST_CHALLENGE = b"CHAINLOGISTICS-RINGSIG-V1-CHALLENGE"
+_DST_RING = b"CHAINLOGISTICS-RINGSIG-V1-RING"
+
+MIN_RING_SIZE = 2
+MAX_RING_SIZE = 32
+
+_FP_BYTES = 48
+_PK_BYTES = 96
+_SCALAR_BYTES = 32
+
+# None is the point at infinity; otherwise an affine (x, y) tuple.
+Point = Optional[Tuple[int, int]]
+
+
+class RingError(Exception):
+    """Raised when signing inputs are invalid."""
+
+
+# ─── Minimal G1 elliptic-curve arithmetic (affine, over F_p) ────────────────
+
+
+def _is_on_curve(pt: Point) -> bool:
+    if pt is None:
+        return True
+    x, y = pt
+    if not (0 <= x < P and 0 <= y < P):
+        return False
+    return (y * y - (x * x * x + B)) % P == 0
+
+
+def _add(p1: Point, p2: Point) -> Point:
+    if p1 is None:
+        return p2
+    if p2 is None:
+        return p1
+    x1, y1 = p1
+    x2, y2 = p2
+    if x1 == x2 and (y1 + y2) % P == 0:
+        return None  # P + (-P) = O
+    if x1 == x2 and y1 == y2:
+        # Doubling: lambda = 3x^2 / 2y
+        lam = (3 * x1 * x1 % P) * pow(2 * y1 % P, -1, P) % P
+    else:
+        lam = (y2 - y1) % P * pow((x2 - x1) % P, -1, P) % P
+    x3 = (lam * lam - x1 - x2) % P
+    y3 = (lam * (x1 - x3) - y1) % P
+    return (x3, y3)
+
+
+def _mul(k: int, pt: Point) -> Point:
+    k %= R
+    result: Point = None
+    addend = pt
+    while k:
+        if k & 1:
+            result = _add(result, addend)
+        addend = _add(addend, addend)
+        k >>= 1
+    return result
+
+
+_G: Point = (GX, GY)
+
+
+# ─── Encoding helpers ───────────────────────────────────────────────────────
+
+
+def _serialize(pt: Point) -> bytes:
+    """Uncompressed G1 encoding (``x ‖ y``, 48 bytes each, big-endian)."""
+    if pt is None:
+        # Never occurs for a valid ring signature.
+        raise RingError("cannot serialize the point at infinity")
+    x, y = pt
+    return x.to_bytes(_FP_BYTES, "big") + y.to_bytes(_FP_BYTES, "big")
+
+
+def _deserialize(data: bytes) -> Point:
+    if len(data) != _PK_BYTES:
+        raise RingError("ring member must be 96 bytes")
+    x = int.from_bytes(data[:_FP_BYTES], "big")
+    y = int.from_bytes(data[_FP_BYTES:], "big")
+    pt = (x, y)
+    if not _is_on_curve(pt):
+        raise RingError("ring member is not on the BLS12-381 curve")
+    return pt
+
+
+# Big-endian integer reduced mod r, mirroring the contract's ``Fr::from_bytes``.
+def _scalar_from_be_reduce(digest: bytes) -> int:
+    return int.from_bytes(digest, "big") % R
+
+
+def _scalar_to_be(s: int) -> bytes:
+    return (s % R).to_bytes(_SCALAR_BYTES, "big")
+
+
+def _sha256(*parts: bytes) -> bytes:
+    h = hashlib.sha256()
+    for p in parts:
+        h.update(p)
+    return h.digest()
+
+
+def aggregate_ring(ring: List[bytes]) -> bytes:
+    """Ring commitment (public-key aggregation); mirrors the contract."""
+    h = hashlib.sha256()
+    h.update(_DST_RING)
+    h.update(len(ring).to_bytes(4, "big"))
+    for member in ring:
+        h.update(member)
+    return h.digest()
+
+
+def _challenge(commit: bytes, msg_digest: bytes, l_bytes: bytes) -> int:
+    return _scalar_from_be_reduce(_sha256(_DST_CHALLENGE, commit, msg_digest, l_bytes))
+
+
+# ─── Public types ───────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RingSignature:
+    """Wire-format ring signature: ``c0`` plus one ``s`` per member, in order."""
+
+    c0: bytes
+    s: List[bytes]
+
+
+@dataclass(frozen=True)
+class KeyPair:
+    """An auditor keypair. ``secret`` is the scalar private key (``0 < x < r``)."""
+
+    secret: int
+
+    @classmethod
+    def generate(cls) -> "KeyPair":
+        return cls(secret=1 + secrets.randbelow(R - 1))
+
+    @classmethod
+    def from_secret_be_bytes(cls, data: bytes) -> "KeyPair":
+        if len(data) != _SCALAR_BYTES:
+            raise RingError("secret key must be 32 bytes")
+        x = int.from_bytes(data, "big")
+        if not (0 < x < R):
+            raise RingError("secret key must be a canonical scalar in [1, r)")
+        return cls(secret=x)
+
+    def secret_be_bytes(self) -> bytes:
+        return _scalar_to_be(self.secret)
+
+    def public_key(self) -> bytes:
+        """Public key ``secret · G``, uncompressed G1 (96 bytes)."""
+        return _serialize(_mul(self.secret, _G))
+
+
+# ─── Verify ─────────────────────────────────────────────────────────────────
+
+
+def verify(ring: List[bytes], message: bytes, sig: RingSignature) -> bool:
+    """``True`` iff ``sig`` is valid for ``ring`` over ``message``. Mirrors the
+    on-chain ``verify``; the authoritative subgroup check is done on-chain."""
+    n = len(ring)
+    if n < MIN_RING_SIZE or n > MAX_RING_SIZE or len(sig.s) != n:
+        return False
+    if len(set(ring)) != n:  # reject duplicate members
+        return False
+
+    try:
+        members = [_deserialize(m) for m in ring]
+    except RingError:
+        return False
+
+    commit = aggregate_ring(ring)
+    msg_digest = _sha256(message)
+
+    c0 = _scalar_from_be_reduce(sig.c0)
+    c = c0
+    for i in range(n):
+        si = _scalar_from_be_reduce(sig.s[i])
+        # L_i = s_i · G + c · P_i
+        l = _add(_mul(si, _G), _mul(c, members[i]))
+        try:
+            l_bytes = _serialize(l)
+        except RingError:
+            return False
+        c = _challenge(commit, msg_digest, l_bytes)
+
+    return c == c0
+
+
+# ─── Sign ─────────────────────────────────────────────────────────────────
+
+
+def sign(
+    ring: List[bytes],
+    signer_index: int,
+    signer: KeyPair,
+    message: bytes,
+) -> RingSignature:
+    """Sign ``message`` as ring member ``signer_index`` (uses a secure RNG)."""
+    n = len(ring)
+    if n < MIN_RING_SIZE:
+        raise RingError("ring smaller than the minimum anonymity set")
+    if n > MAX_RING_SIZE:
+        raise RingError("ring larger than the maximum supported size")
+    if not (0 <= signer_index < n):
+        raise RingError("signer index is outside the ring")
+    if signer.public_key() != ring[signer_index]:
+        raise RingError("secret key does not match the ring member")
+
+    members = [_deserialize(m) for m in ring]
+    commit = aggregate_ring(ring)
+    msg_digest = _sha256(message)
+
+    c = [0] * n
+    s = [0] * n
+
+    def rand_scalar() -> int:
+        return secrets.randbelow(R)
+
+    # Seed the chain at the signer's index with a random nonce alpha.
+    alpha = rand_scalar()
+    l_pi = _serialize(_mul(alpha, _G))
+    c[(signer_index + 1) % n] = _challenge(commit, msg_digest, l_pi)
+
+    # Walk the decoys with random responses.
+    for j in range(1, n):
+        idx = (signer_index + j) % n
+        s[idx] = rand_scalar()
+        l = _add(_mul(s[idx], _G), _mul(c[idx], members[idx]))
+        c[(idx + 1) % n] = _challenge(commit, msg_digest, _serialize(l))
+
+    # Close the ring: s_pi = alpha - c_pi · x  (mod r).
+    s[signer_index] = (alpha - c[signer_index] * signer.secret) % R
+
+    return RingSignature(
+        c0=_scalar_to_be(c[0]),
+        s=[_scalar_to_be(v) for v in s],
+    )

--- a/sdk/python/tests/test_ring_signature.py
+++ b/sdk/python/tests/test_ring_signature.py
@@ -1,0 +1,132 @@
+"""Tests for the ring-signature module, including a known-answer vector from the
+Soroban contract (``test_verifies_contract_test_vector``) that proves on-chain
+agreement."""
+
+from chainlogistics_sdk.ring_signature import (
+    GX,
+    GY,
+    KeyPair,
+    RingSignature,
+    aggregate_ring,
+    sign,
+    verify,
+    _G,
+    _is_on_curve,
+    _mul,
+    _serialize,
+    R,
+)
+
+
+# Generator uncompressed bytes, matching the contract's `G1_GENERATOR`.
+G1_GENERATOR = bytes.fromhex(
+    "17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac58"
+    "6c55e83ff97a1aeffb3af00adb22c6bb08b3f481e3aaa0f1a09e30ed741d8ae4"
+    "fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1"
+)
+
+
+def test_generator_is_on_curve_and_matches_constant():
+    assert _is_on_curve(_G)
+    assert _serialize(_G) == G1_GENERATOR
+    assert (GX, GY) == _G
+
+
+def test_generator_has_prime_order():
+    # r · G == O (point at infinity): confirms G is in the prime-order subgroup.
+    assert _mul(R, _G) is None
+
+
+def test_sign_and_verify_round_trip_all_indices():
+    keys = [KeyPair.generate() for _ in range(5)]
+    ring = [k.public_key() for k in keys]
+    msg = b"audit attestation"
+    for signer in range(len(ring)):
+        sig = sign(ring, signer, keys[signer], msg)
+        assert verify(ring, msg, sig), f"signer {signer} must verify"
+
+
+def test_wrong_message_fails():
+    keys = [KeyPair.generate() for _ in range(3)]
+    ring = [k.public_key() for k in keys]
+    sig = sign(ring, 0, keys[0], b"original")
+    assert not verify(ring, b"tampered", sig)
+
+
+def test_anonymity_set_must_match():
+    keys = [KeyPair.generate() for _ in range(3)]
+    ring = [k.public_key() for k in keys]
+    sig = sign(ring, 0, keys[0], b"x")
+    ring[2] = KeyPair.generate().public_key()  # change the set
+    assert not verify(ring, b"x", sig)
+
+
+def test_tampered_response_fails():
+    keys = [KeyPair.generate() for _ in range(4)]
+    ring = [k.public_key() for k in keys]
+    sig = sign(ring, 2, keys[2], b"statement")
+    bad = RingSignature(c0=sig.c0, s=list(sig.s))
+    bad.s[0] = bytes([7]) * 32
+    assert not verify(ring, b"statement", bad)
+
+
+def test_wrong_secret_is_rejected():
+    keys = [KeyPair.generate() for _ in range(3)]
+    ring = [k.public_key() for k in keys]
+    try:
+        sign(ring, 0, keys[1], b"x")  # keys[1] claims to be index 0
+        assert False, "expected RingError"
+    except Exception as exc:  # noqa: BLE001
+        assert "secret key" in str(exc)
+
+
+def test_aggregate_ring_order_sensitive():
+    keys = [KeyPair.generate() for _ in range(4)]
+    ring = [k.public_key() for k in keys]
+    assert aggregate_ring(ring) == aggregate_ring(ring)
+    reordered = [ring[1], ring[0], ring[2], ring[3]]
+    assert aggregate_ring(ring) != aggregate_ring(reordered)
+
+
+def test_verifies_contract_test_vector():
+    """Known-answer cross-implementation test against the Soroban contract."""
+    ring = [
+        bytes.fromhex(
+            "102b6a1c88da96b327e995c2159fb4f88070cd144de9e1f0a7aaa2dd37b3bb2b"
+            "643a7dcfcdab05352d0156ffec6070d8054b2cef273b023043e72ed27862dd24"
+            "73202e84cf1365128dafd26ba683b24fa7b527d2242d285cae0a77cbb0d9f396"
+        ),
+        bytes.fromhex(
+            "15f5d598f843ec0b0a4d2368f516ead2e877ba2300148c10a56296de419cee64"
+            "de75225a023341475bb67eb260f1edf20b8f39782375c2c7f0f2b1b975e9611f"
+            "84497ff5920dd56aa3907e8a6ef1653af2f2bfdec459770fef0d799bd2d8cb31"
+        ),
+        bytes.fromhex(
+            "04ff5071f60786edbd7f589e91c5c9ab0d7d0066b00dfbdf35520f1d50c0b1f9"
+            "4e30a5c4abd093af78c762b7ab9709171297418166538f09f4cb6b89d46f6cc5"
+            "c5e516234b99966cd092a8e34456db97b3fda3e1031c53ad159703f4f85ab514"
+        ),
+    ]
+    message = b"handover: PROD-7 alice->bob nonce=42"
+    sig = RingSignature(
+        c0=bytes.fromhex(
+            "3a56f0800412258de421b9146df64ee8db80385159874874b6e547b6351aef5f"
+        ),
+        s=[
+            bytes.fromhex(
+                "3500922125d31fe353ae32a2feed0e71dbf5b17df41348cae610abdd040dc442"
+            ),
+            bytes.fromhex(
+                "1a6b9d69a28c59dbbf06001b3a7c0f96db375e65aab99db4d8c5ac885b908adb"
+            ),
+            bytes.fromhex(
+                "3fb8309bbe0e15d5dc1c5ad87ab8e74647e660e19d4d8e99d3a1434ee9f3b0b1"
+            ),
+        ],
+    )
+
+    assert verify(ring, message, sig), "must accept contract-produced signature"
+    assert not verify(ring, b"wrong", sig)
+    assert aggregate_ring(ring) == bytes.fromhex(
+        "0bbfd715e9206cdf3e965c10b5a1b7f57a099a7b72e105151852e51cfbe7fc80"
+    )

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -67,6 +67,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bls12_381"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
+dependencies = [
+ "ff",
+ "group",
+ "pairing",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,11 +132,15 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 name = "chainlogistics-sdk"
 version = "1.0.0"
 dependencies = [
+ "bls12_381",
  "chrono",
  "mockito",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "tokio",
  "tokio-test",
@@ -130,7 +168,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -148,6 +186,35 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -176,6 +243,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "bitvec",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +279,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -242,6 +326,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +369,17 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -742,6 +847,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,13 +955,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -857,7 +987,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1083,6 +1222,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,6 +1281,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1182,6 +1338,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -1223,7 +1385,19 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "socket2 0.6.3",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1303,6 +1477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1529,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1798,6 +1984,15 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yoke"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -18,12 +18,20 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 thiserror = "1.0"
 url = "2.0"
-tokio = { version = "1.0", features = ["rt-multi-thread"], optional = true }
+tokio = { version = "1.0", features = ["rt-multi-thread", "macros"], optional = true }
+# Ring-signature signing (privacy-preserving audit trail). Optional so the HTTP
+# client stays dependency-light when the feature is unused.
+bls12_381 = { version = "0.8", optional = true }
+sha2 = { version = "0.10", optional = true }
+rand_core = { version = "0.6", features = ["getrandom"], optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4"
 mockito = "1.0"
+rand_chacha = "0.3"
 
 [features]
 default = ["client"]
 client = ["tokio"]
+# Enables the `ring_signature` module for anonymous audit attestations.
+ring-signatures = ["bls12_381", "sha2", "rand_core"]

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -36,6 +36,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 - `events()`: tracking event operations.
 - `stats()`: global metrics and health endpoints.
 
+## Ring signatures (privacy-preserving audit trail)
+
+Enable the `ring-signatures` feature to sign audit attestations anonymously as
+one member of a ring of auditors (BLS12-381). Signatures verify on-chain via the
+`AuditTrailContract` / `RingSignatureVerifier` Soroban contracts unchanged.
+
+```toml
+chainlogistics-sdk = { version = "1.0.0", features = ["ring-signatures"] }
+```
+
+```rust
+use chainlogistics_sdk::ring_signature::{KeyPair, sign, verify};
+use rand_core::OsRng;
+
+let auditors: Vec<KeyPair> = (0..8).map(|_| KeyPair::generate(OsRng)).collect();
+let ring: Vec<[u8; 96]> = auditors.iter().map(|k| k.public_key()).collect();
+
+let msg = b"custody: warehouse-A -> truck-7";
+let sig = sign(&ring, 3, &auditors[3], msg, OsRng).unwrap(); // auditor #3, anonymously
+assert!(verify(&ring, msg, &sig));
+```
+
+See `smart-contract/RING_SIGNATURE.md` for the full scheme, gas costs and
+linkability analysis.
+
 ## Additional Documentation
 
 - Shared SDK docs: `sdk/README.md`

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -30,6 +30,12 @@ pub mod products;
 pub mod events;
 pub mod stats;
 
+/// Privacy-preserving audit-trail ring signatures (BLS12-381). Enable with the
+/// `ring-signatures` feature. Interoperates with the Soroban
+/// `RingSignatureVerifier` / `AuditTrailContract` contracts.
+#[cfg(feature = "ring-signatures")]
+pub mod ring_signature;
+
 // Re-export main types for convenience
 pub use client::ChainLogisticsClient;
 pub use config::Config;

--- a/sdk/rust/src/ring_signature.rs
+++ b/sdk/rust/src/ring_signature.rs
@@ -1,0 +1,379 @@
+//! AOS/SAG ring signatures over BLS12-381 G1 — the off-chain counterpart to
+//! the `RingSignatureVerifier` / `AuditTrailContract` Soroban contracts. An
+//! auditor signs a statement as an anonymous member of a ring; the signature
+//! verifies on-chain unchanged (cross-checked against a contract-produced
+//! vector in [`tests`]).
+//!
+//! Wire format (must match the contract): a public key is the uncompressed G1
+//! encoding (`x ‖ y`, 48 bytes each, big-endian) = `[u8; 96]`; each scalar
+//! (`c0`, `s_i`) is a 32-byte big-endian canonical `F_r` element; the challenge
+//! reduces `SHA-256(...)` as a big-endian integer mod `r`.
+//!
+//! ```
+//! use chainlogistics_sdk::ring_signature::{KeyPair, sign, verify};
+//! use rand_core::OsRng;
+//!
+//! let auditors: Vec<KeyPair> = (0..3).map(|_| KeyPair::generate(OsRng)).collect();
+//! let ring: Vec<[u8; 96]> = auditors.iter().map(|k| k.public_key()).collect();
+//!
+//! let msg = b"custody: warehouse-A -> truck-7";
+//! let sig = sign(&ring, 1, &auditors[1], msg, OsRng).unwrap();
+//! assert!(verify(&ring, msg, &sig));
+//! assert!(!verify(&ring, b"different message", &sig));
+//! ```
+
+use bls12_381::{G1Affine, G1Projective, Scalar};
+use rand_core::RngCore;
+use sha2::{Digest, Sha256};
+
+// Must match the Soroban contract byte-for-byte.
+const DST_CHALLENGE: &[u8] = b"CHAINLOGISTICS-RINGSIG-V1-CHALLENGE";
+const DST_RING: &[u8] = b"CHAINLOGISTICS-RINGSIG-V1-RING";
+
+pub const MIN_RING_SIZE: usize = 2;
+pub const MAX_RING_SIZE: usize = 32;
+
+/// Errors returned by signing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RingError {
+    RingTooSmall,
+    RingTooLarge,
+    SignerIndexOutOfRange,
+    InvalidRingMember,
+    SecretKeyMismatch,
+}
+
+impl std::fmt::Display for RingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            RingError::RingTooSmall => "ring smaller than the minimum anonymity set",
+            RingError::RingTooLarge => "ring larger than the maximum supported size",
+            RingError::SignerIndexOutOfRange => "signer index is outside the ring",
+            RingError::InvalidRingMember => "ring contains an invalid G1 point",
+            RingError::SecretKeyMismatch => "secret key does not match the ring member",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::error::Error for RingError {}
+
+/// A ring signature in the contract's wire format (`c0` + one `s` per member).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RingSignature {
+    pub c0: [u8; 32],
+    pub s: Vec<[u8; 32]>,
+}
+
+/// An auditor keypair. `secret` is the BLS12-381 scalar private key.
+#[derive(Debug, Clone)]
+pub struct KeyPair {
+    secret: Scalar,
+}
+
+impl KeyPair {
+    pub fn generate<R: RngCore>(mut rng: R) -> Self {
+        let mut wide = [0u8; 64];
+        rng.fill_bytes(&mut wide);
+        KeyPair {
+            secret: Scalar::from_bytes_wide(&wide),
+        }
+    }
+
+    /// `None` if `bytes` is not a canonical scalar (`>= r`).
+    pub fn from_secret_be_bytes(bytes: &[u8; 32]) -> Option<Self> {
+        scalar_from_be_canonical(bytes).map(|secret| KeyPair { secret })
+    }
+
+    pub fn secret_be_bytes(&self) -> [u8; 32] {
+        scalar_to_be(&self.secret)
+    }
+
+    pub fn public_key(&self) -> [u8; 96] {
+        G1Affine::from(G1Projective::generator() * self.secret).to_uncompressed()
+    }
+}
+
+// ─── Encoding helpers (big-endian wire <-> zkcrypto little-endian) ──────────
+
+// Big-endian digest reduced mod r, mirroring the contract's `Fr::from_bytes`.
+fn scalar_from_be_reduce(be: &[u8; 32]) -> Scalar {
+    let mut le_wide = [0u8; 64];
+    for i in 0..32 {
+        le_wide[i] = be[31 - i];
+    }
+    Scalar::from_bytes_wide(&le_wide)
+}
+
+fn scalar_from_be_canonical(be: &[u8; 32]) -> Option<Scalar> {
+    let mut le = [0u8; 32];
+    for i in 0..32 {
+        le[i] = be[31 - i];
+    }
+    Option::from(Scalar::from_bytes(&le))
+}
+
+fn scalar_to_be(s: &Scalar) -> [u8; 32] {
+    let le = s.to_bytes();
+    let mut be = [0u8; 32];
+    for i in 0..32 {
+        be[i] = le[31 - i];
+    }
+    be
+}
+
+fn sha256(parts: &[&[u8]]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    for p in parts {
+        h.update(p);
+    }
+    h.finalize().into()
+}
+
+/// Ring commitment (public-key aggregation); mirrors the contract.
+pub fn aggregate_ring(ring: &[[u8; 96]]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(DST_RING);
+    h.update((ring.len() as u32).to_be_bytes());
+    for member in ring {
+        h.update(member);
+    }
+    h.finalize().into()
+}
+
+fn challenge(commit: &[u8; 32], msg_digest: &[u8; 32], l_uncompressed: &[u8; 96]) -> Scalar {
+    let digest = sha256(&[DST_CHALLENGE, commit, msg_digest, l_uncompressed]);
+    scalar_from_be_reduce(&digest)
+}
+
+fn parse_member(bytes: &[u8; 96]) -> Option<G1Affine> {
+    // from_uncompressed enforces on-curve + prime-subgroup, matching the
+    // contract's g1_is_in_subgroup.
+    Option::from(G1Affine::from_uncompressed(bytes))
+}
+
+// ─── Verify ─────────────────────────────────────────────────────────────────
+
+/// `true` iff `sig` was produced by a holder of one of the `ring` keys over
+/// `message`. Mirrors the on-chain `verify`.
+pub fn verify(ring: &[[u8; 96]], message: &[u8], sig: &RingSignature) -> bool {
+    let n = ring.len();
+    if n < MIN_RING_SIZE || n > MAX_RING_SIZE || sig.s.len() != n {
+        return false;
+    }
+
+    let mut members = Vec::with_capacity(n);
+    for member in ring {
+        match parse_member(member) {
+            Some(p) => members.push(G1Projective::from(p)),
+            None => return false,
+        }
+        // Reject duplicates (shrinks the effective anonymity set).
+        for j in 0..members.len() - 1 {
+            if ring[j] == *member {
+                return false;
+            }
+        }
+    }
+
+    let g = G1Projective::generator();
+    let commit = aggregate_ring(ring);
+    let msg_digest = sha256(&[message]);
+
+    let c0 = scalar_from_be_reduce(&sig.c0);
+    let mut c = c0;
+    for i in 0..n {
+        let si = scalar_from_be_reduce(&sig.s[i]);
+        // L_i = s_i · G + c · P_i
+        let l = g * si + members[i] * c;
+        let l_bytes = G1Affine::from(l).to_uncompressed();
+        c = challenge(&commit, &msg_digest, &l_bytes);
+    }
+
+    c == c0
+}
+
+// ─── Sign ─────────────────────────────────────────────────────────────────
+
+/// Sign `message` as ring member `signer_index`. `rng` must be a CSPRNG.
+pub fn sign<R: RngCore>(
+    ring: &[[u8; 96]],
+    signer_index: usize,
+    signer: &KeyPair,
+    message: &[u8],
+    mut rng: R,
+) -> Result<RingSignature, RingError> {
+    let n = ring.len();
+    if n < MIN_RING_SIZE {
+        return Err(RingError::RingTooSmall);
+    }
+    if n > MAX_RING_SIZE {
+        return Err(RingError::RingTooLarge);
+    }
+    if signer_index >= n {
+        return Err(RingError::SignerIndexOutOfRange);
+    }
+    if signer.public_key() != ring[signer_index] {
+        return Err(RingError::SecretKeyMismatch);
+    }
+
+    let mut members = Vec::with_capacity(n);
+    for member in ring {
+        members.push(G1Projective::from(
+            parse_member(member).ok_or(RingError::InvalidRingMember)?,
+        ));
+    }
+
+    let g = G1Projective::generator();
+    let commit = aggregate_ring(ring);
+    let msg_digest = sha256(&[message]);
+
+    let mut c = vec![Scalar::from(0u64); n];
+    let mut s = vec![Scalar::from(0u64); n];
+
+    let random_scalar = |rng: &mut R| {
+        let mut wide = [0u8; 64];
+        rng.fill_bytes(&mut wide);
+        Scalar::from_bytes_wide(&wide)
+    };
+
+    // Seed the chain at the signer's index with a random nonce α.
+    let alpha = random_scalar(&mut rng);
+    let l_pi = G1Affine::from(g * alpha).to_uncompressed();
+    c[(signer_index + 1) % n] = challenge(&commit, &msg_digest, &l_pi);
+
+    // Walk the decoys with random responses.
+    for j in 1..n {
+        let idx = (signer_index + j) % n;
+        let s_idx = random_scalar(&mut rng);
+        s[idx] = s_idx;
+        let l = g * s_idx + members[idx] * c[idx];
+        let l_bytes = G1Affine::from(l).to_uncompressed();
+        c[(idx + 1) % n] = challenge(&commit, &msg_digest, &l_bytes);
+    }
+
+    // Close the ring: s_π = α − c_π · x.
+    s[signer_index] = alpha - c[signer_index] * signer.secret;
+
+    Ok(RingSignature {
+        c0: scalar_to_be(&c[0]),
+        s: s.iter().map(scalar_to_be).collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand_core::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
+
+    // The contract's hardcoded `G1_GENERATOR`.
+    const G1_GENERATOR: [u8; 96] = [
+        0x17, 0xf1, 0xd3, 0xa7, 0x31, 0x97, 0xd7, 0x94, 0x26, 0x95, 0x63, 0x8c, 0x4f, 0xa9, 0xac,
+        0x0f, 0xc3, 0x68, 0x8c, 0x4f, 0x97, 0x74, 0xb9, 0x05, 0xa1, 0x4e, 0x3a, 0x3f, 0x17, 0x1b,
+        0xac, 0x58, 0x6c, 0x55, 0xe8, 0x3f, 0xf9, 0x7a, 0x1a, 0xef, 0xfb, 0x3a, 0xf0, 0x0a, 0xdb,
+        0x22, 0xc6, 0xbb, 0x08, 0xb3, 0xf4, 0x81, 0xe3, 0xaa, 0xa0, 0xf1, 0xa0, 0x9e, 0x30, 0xed,
+        0x74, 0x1d, 0x8a, 0xe4, 0xfc, 0xf5, 0xe0, 0x95, 0xd5, 0xd0, 0x0a, 0xf6, 0x00, 0xdb, 0x18,
+        0xcb, 0x2c, 0x04, 0xb3, 0xed, 0xd0, 0x3c, 0xc7, 0x44, 0xa2, 0x88, 0x8a, 0xe4, 0x0c, 0xaa,
+        0x23, 0x29, 0x46, 0xc5, 0xe7, 0xe1,
+    ];
+
+    fn hex_to_array<const N: usize>(s: &str) -> [u8; N] {
+        let mut out = [0u8; N];
+        for i in 0..N {
+            out[i] = u8::from_str_radix(&s[2 * i..2 * i + 2], 16).unwrap();
+        }
+        out
+    }
+
+    fn rng(seed: u64) -> ChaCha20Rng {
+        ChaCha20Rng::seed_from_u64(seed)
+    }
+
+    #[test]
+    fn generator_matches_contract_constant() {
+        // Interop requires both sides to use the same fixed generator.
+        assert_eq!(G1Affine::generator().to_uncompressed(), G1_GENERATOR);
+    }
+
+    #[test]
+    fn sign_and_verify_round_trip() {
+        let mut r = rng(1);
+        let keys: Vec<KeyPair> = (0..5).map(|_| KeyPair::generate(&mut r)).collect();
+        let ring: Vec<[u8; 96]> = keys.iter().map(|k| k.public_key()).collect();
+        let msg = b"audit attestation";
+        for signer in 0..ring.len() {
+            let sig = sign(&ring, signer, &keys[signer], msg, rng(100 + signer as u64)).unwrap();
+            assert!(verify(&ring, msg, &sig), "signer {signer} must verify");
+        }
+    }
+
+    #[test]
+    fn wrong_message_fails() {
+        let mut r = rng(2);
+        let keys: Vec<KeyPair> = (0..3).map(|_| KeyPair::generate(&mut r)).collect();
+        let ring: Vec<[u8; 96]> = keys.iter().map(|k| k.public_key()).collect();
+        let sig = sign(&ring, 0, &keys[0], b"original", rng(7)).unwrap();
+        assert!(!verify(&ring, b"tampered", &sig));
+    }
+
+    #[test]
+    fn anonymity_set_must_match() {
+        let mut r = rng(3);
+        let keys: Vec<KeyPair> = (0..3).map(|_| KeyPair::generate(&mut r)).collect();
+        let mut ring: Vec<[u8; 96]> = keys.iter().map(|k| k.public_key()).collect();
+        let sig = sign(&ring, 0, &keys[0], b"x", rng(8)).unwrap();
+        // Swap a member -> ring commitment changes -> verification fails.
+        ring[2] = KeyPair::generate(&mut r).public_key();
+        assert!(!verify(&ring, b"x", &sig));
+    }
+
+    #[test]
+    fn wrong_secret_is_rejected() {
+        let mut r = rng(4);
+        let keys: Vec<KeyPair> = (0..3).map(|_| KeyPair::generate(&mut r)).collect();
+        let ring: Vec<[u8; 96]> = keys.iter().map(|k| k.public_key()).collect();
+        // keys[1] tries to sign claiming to be index 0.
+        let err = sign(&ring, 0, &keys[1], b"x", rng(9)).unwrap_err();
+        assert_eq!(err, RingError::SecretKeyMismatch);
+    }
+
+    #[test]
+    fn ring_too_small_is_rejected() {
+        let k = KeyPair::generate(rng(5));
+        let ring = vec![k.public_key()];
+        assert_eq!(
+            sign(&ring, 0, &k, b"x", rng(5)).unwrap_err(),
+            RingError::RingTooSmall
+        );
+    }
+
+    // Known-answer vector from the contract's `emit_sdk_test_vector`. Accepting
+    // it proves byte-for-byte agreement with the on-chain verifier.
+    #[test]
+    fn verifies_contract_test_vector() {
+        let ring = vec![
+            hex_to_array::<96>("102b6a1c88da96b327e995c2159fb4f88070cd144de9e1f0a7aaa2dd37b3bb2b643a7dcfcdab05352d0156ffec6070d8054b2cef273b023043e72ed27862dd2473202e84cf1365128dafd26ba683b24fa7b527d2242d285cae0a77cbb0d9f396"),
+            hex_to_array::<96>("15f5d598f843ec0b0a4d2368f516ead2e877ba2300148c10a56296de419cee64de75225a023341475bb67eb260f1edf20b8f39782375c2c7f0f2b1b975e9611f84497ff5920dd56aa3907e8a6ef1653af2f2bfdec459770fef0d799bd2d8cb31"),
+            hex_to_array::<96>("04ff5071f60786edbd7f589e91c5c9ab0d7d0066b00dfbdf35520f1d50c0b1f94e30a5c4abd093af78c762b7ab9709171297418166538f09f4cb6b89d46f6cc5c5e516234b99966cd092a8e34456db97b3fda3e1031c53ad159703f4f85ab514"),
+        ];
+        let message = b"handover: PROD-7 alice->bob nonce=42";
+        let sig = RingSignature {
+            c0: hex_to_array::<32>("3a56f0800412258de421b9146df64ee8db80385159874874b6e547b6351aef5f"),
+            s: vec![
+                hex_to_array::<32>("3500922125d31fe353ae32a2feed0e71dbf5b17df41348cae610abdd040dc442"),
+                hex_to_array::<32>("1a6b9d69a28c59dbbf06001b3a7c0f96db375e65aab99db4d8c5ac885b908adb"),
+                hex_to_array::<32>("3fb8309bbe0e15d5dc1c5ad87ab8e74647e660e19d4d8e99d3a1434ee9f3b0b1"),
+            ],
+        };
+
+        assert!(verify(&ring, message, &sig), "must accept contract vector");
+        assert!(!verify(&ring, b"wrong", &sig));
+
+        // Aggregation must also match the contract's commitment.
+        assert_eq!(
+            aggregate_ring(&ring),
+            hex_to_array::<32>("0bbfd715e9206cdf3e965c10b5a1b7f57a099a7b72e105151852e51cfbe7fc80")
+        );
+    }
+}

--- a/smart-contract/RING_SIGNATURE.md
+++ b/smart-contract/RING_SIGNATURE.md
@@ -1,0 +1,282 @@
+# Privacy-Preserving Audit Trail with Ring Signatures
+
+> Resolves issue #413. Depends on the BLS12-381 host functions (CAP-0059)
+> already used by the Groth16 `ComplianceVerifier`.
+
+Auditors of a supply chain must be able to attest to product handovers (custody
+changes, inspections, sign-offs) **without revealing which specific auditor
+signed**. A named signature exposes the auditor to bribery, coercion or
+retaliation. A *ring signature* solves this: a member of an *anonymity set* (the
+*ring*) produces a signature that anyone can verify came from **one of** the
+ring members, but no one — not even the verifier or the relayer that submits the
+transaction — can tell **which** one.
+
+This document specifies the scheme, the on-chain/off-chain APIs, the measured
+gas costs, and answers the design questions raised in the issue (gas
+feasibility, linkability, and short ring signatures).
+
+---
+
+## 1. Scheme
+
+We use an **AOS / SAG ring signature** (Abe–Ohkubo–Suzuki / Spontaneous
+Anonymous Group) over the **BLS12-381 G1** prime-order group. It needs only host
+functions Soroban exposes today — `g1_mul`, `g1_add`, `g1_is_in_subgroup`,
+`sha256` — and **no pairings**, so verification is far cheaper than a SNARK.
+
+Let `G` be the standard BLS12-381 G1 generator and `r` the scalar field order.
+Each auditor has a secret `x_i ∈ F_r` and public key `P_i = x_i · G`. For a ring
+`P_0 … P_{n-1}` and message `m`, a signature is `(c_0, [s_0 … s_{n-1}])` where
+every `s_i` and `c_0` is a scalar in `F_r`.
+
+### Verification
+
+```
+commit = SHA256( DST_RING ‖ n(be32) ‖ P_0 ‖ … ‖ P_{n-1} )      // ring commitment
+md     = SHA256(m)
+c      = c_0
+for i in 0..n:
+    L_i = s_i · G + c · P_i
+    c   = SHA256( DST_CHALLENGE ‖ commit ‖ md ‖ L_i ) mod r
+accept iff c == c_0
+```
+
+### Signing (performed by the SDKs)
+
+The signer knows one secret `x_π`. It picks a uniformly random nonce `α`, seeds
+the challenge chain at its own index with `L_π = α · G`, fills the other
+positions with uniformly random responses `s_i`, then **closes the ring** with
+
+```
+s_π = α − c_π · x_π   (mod r)
+```
+
+Anonymity follows from `α` and the decoy `s_i` being uniformly random: given a
+valid signature, every index is equally likely to be the true signer.
+
+### Domain separation & parameters
+
+| Parameter        | Value                                                      |
+|------------------|------------------------------------------------------------|
+| Curve / group    | BLS12-381, G1 (prime order `r`)                            |
+| Generator `G`    | Standard G1 generator (uncompressed, hardcoded + validated)|
+| `DST_CHALLENGE`  | `CHAINLOGISTICS-RINGSIG-V1-CHALLENGE`                      |
+| `DST_RING`       | `CHAINLOGISTICS-RINGSIG-V1-RING`                           |
+| Hash-to-scalar   | `int.from_bytes(SHA256(...), "big") mod r`                |
+| Min / max ring   | 2 / 32                                                      |
+
+### Wire format
+
+* **Public key** — uncompressed G1 (`x ‖ y`, 48 bytes each, big-endian) = 96 bytes.
+* **Scalar** (`c_0`, each `s_i`) — 32-byte **big-endian** canonical `F_r` element.
+
+These match `soroban_sdk` `Bls12381G1Affine` and `Fr` serialization exactly,
+which is what lets a signature cross the off-chain/on-chain boundary unchanged.
+
+---
+
+## 2. Public-key aggregation
+
+`aggregate_ring(ring)` derives the canonical, **order- and size-binding** ring
+commitment `commit = SHA256(DST_RING ‖ n ‖ P_0 ‖ … ‖ P_{n-1})`. It serves two
+purposes:
+
+1. A stable identifier for an anonymity set (stored with each audit record).
+2. It is folded into every challenge, cryptographically binding a signature to
+   *exactly* the ring it was produced for. Members cannot be added, removed or
+   reordered after the fact without invalidating the signature.
+
+---
+
+## 3. APIs
+
+### On-chain (Soroban — `contracts/src/ring_signature.rs`)
+
+`RingSignatureVerifier` (stateless verification gateway):
+
+| Method | Description |
+|--------|-------------|
+| `verify(ring, message, sig) -> bool` | `true` iff `sig` is valid for the ring. |
+| `verify_strict(ring, message, sig) -> Result<(), Error>` | Same, but returns the precise rejection reason. |
+| `aggregate_ring(ring) -> BytesN<32>` | Ring commitment (public-key aggregation). |
+| `generator() -> BytesN<96>` | The fixed generator, so clients can assert parameter agreement. |
+
+`AuditTrailContract` (stateful, records anonymous handovers):
+
+| Method | Description |
+|--------|-------------|
+| `init(main_contract)` | Wire in the main contract (for the global pause). |
+| `record_handover(product_id, ring, statement, sig) -> u64` | Verify a ring signature and store an **anonymous** `HandoverRecord` + emit `PrivacyHandoverRecorded`. Returns the record id. |
+| `get_handover(record_id)` | Fetch a record. |
+| `product_handovers(product_id)` | Record ids for a product. |
+| `total_handovers()` | Global count. |
+
+A `HandoverRecord` stores only `{ record_id, product_id, ring_commitment,
+ring_size, statement_hash, timestamp }` — **never a signer identity**. The
+submitting account is not recorded either, so a relayer learns nothing about the
+signer beyond ring membership.
+
+### Off-chain (Rust SDK — `sdk/rust`, feature `ring-signatures`)
+
+```rust
+use chainlogistics_sdk::ring_signature::{KeyPair, sign, verify};
+use rand_core::OsRng;
+
+let auditors: Vec<KeyPair> = (0..8).map(|_| KeyPair::generate(OsRng)).collect();
+let ring: Vec<[u8; 96]> = auditors.iter().map(|k| k.public_key()).collect();
+
+let msg = b"custody: warehouse-A -> truck-7";
+let sig = sign(&ring, 3, &auditors[3], msg, OsRng)?;   // auditor #3 signs anonymously
+assert!(verify(&ring, msg, &sig));
+```
+
+### Off-chain (Python SDK — `sdk/python`, no extra dependencies)
+
+```python
+from chainlogistics_sdk.ring_signature import KeyPair, sign, verify
+
+auditors = [KeyPair.generate() for _ in range(8)]
+ring = [k.public_key() for k in auditors]
+
+msg = b"custody: warehouse-A -> truck-7"
+sig = sign(ring, 3, auditors[3], msg)
+assert verify(ring, msg, sig)
+```
+
+`sig.c0` / `sig.s` (and `KeyPair.public_key()`) are exactly the bytes the
+contract's `record_handover` expects.
+
+---
+
+## 4. Design question — on-chain gas feasibility
+
+Verification is `~2` G1 scalar-multiplications + `1` point-addition + `1`
+SHA-256 **per ring member**. Measured with the soroban test host
+(`gas_costs_across_ring_sizes`, run `cargo test ring_signature -- --nocapture`):
+
+| Ring size | CPU instructions | Memory (bytes) |
+|----------:|-----------------:|---------------:|
+| 2         | 14,978,928       | 12,245         |
+| 4         | 29,910,532       | 17,617         |
+| 8         | 59,816,133       | 30,408         |
+| 16        | 119,599,717      | 58,808         |
+| 32        | 239,391,636      | 136,009        |
+
+Cost is **linear** at ≈ **7.5M CPU instructions / member**.
+
+**Feasibility.** Soroban's per-transaction CPU budget is 100M instructions. The
+host documents that *native* estimates **underestimate** the WASM equivalent, so
+treat the table as a lower bound. Practical guidance:
+
+* **Recommended on-chain ring size: ≤ 8** (comfortably inside budget with WASM
+  headroom). A ring of 8 gives 1-in-8 anonymity per attestation.
+* **Hard cap: 32** (`MAX_RING_SIZE`) — enforced so a single call can never be
+  pushed past the budget by an oversized ring. Sizes above ~13 will likely
+  exceed the budget once compiled to WASM and should be validated on testnet
+  first, or use the short-ring-signature path (§6).
+* For larger *effective* anonymity sets without per-call cost, rotate rings over
+  time or aggregate anonymity across many attestations.
+
+Memory is negligible (≤ 136 KB at the cap).
+
+---
+
+## 5. Design question — linkability requirements
+
+**The V1 wire scheme is intentionally _unlinkable_.** Two attestations from the
+same auditor over the same ring cannot be correlated. This maximizes anonymity
+and is the correct default for "anonymous attestation": an auditor signing many
+handovers leaks no graph linking those handovers to one identity.
+
+When a deployment instead needs **one-attestation-per-auditor** (e.g. anonymous
+*voting* on a dispute, where double-voting must be detectable), upgrade to the
+**LSAG** (Linkable Spontaneous Anonymous Group) variant:
+
+* Add a **key image** `I = x · H_p(P)`, where `H_p` maps a public key to a G1
+  point. Soroban exposes `hash_to_g1(msg, dst)` (CAP-0059), so this is available
+  on-chain.
+* Add a second challenge term `R_i = s_i · H_p(P_i) + c · I` and fold `R_i` into
+  the challenge hash alongside `L_i`.
+* `I` is deterministic in the signer's key, so the contract can reject a second
+  attestation carrying a previously-seen `I` (the `KeyImageAlreadyUsed` error and
+  the key-image storage hooks are reserved for this).
+
+LSAG keeps signer anonymity *within* the ring while making repeat-signing
+detectable. The trade-off: it requires both SDKs to reproduce the RFC 9380
+`BLS12381G1_XMD:SHA-256_SSWU_RO_` hash-to-curve **bit-for-bit** with the
+contract's DST; that interop must be pinned with cross-implementation test
+vectors (as done for V1) before enabling it. It is therefore staged as a V2
+rather than shipped on by default.
+
+---
+
+## 6. Optimization idea — short ring signatures
+
+The V1 signature size is `O(n)` (one 32-byte scalar per member, plus `c_0`).
+Options to shrink the ledger footprint / raise the practical ring size:
+
+1. **bLSAG / compact AOS** — already minimal in field elements; the main lever
+   is encoding (e.g. drop to compressed 48-byte G1 keys on the wire and
+   decompress on-chain, halving the public-key payload).
+2. **Accumulator membership** — commit the ring to a Merkle root or a
+   pairing-based accumulator and prove membership with a single Groth16 proof.
+   Verification becomes `O(1)` in ring size, reusing the existing
+   `ComplianceVerifier` pairing path. This is the most promising route to large
+   anonymity sets (hundreds of auditors) at constant gas.
+3. **Back-reference rings** — store the ring once (keyed by its commitment) and
+   have later attestations reference the commitment instead of re-sending all
+   public keys, eliminating the dominant on-chain data cost for repeated rings.
+
+(2) is the recommended long-term direction; (1) and (3) are incremental wins
+that need no new cryptography.
+
+---
+
+## 7. Security notes
+
+* **Subgroup checks.** Every ring member is checked with `g1_is_in_subgroup`
+  (which also validates on-curve), rejecting small-subgroup / invalid-curve
+  forgeries (`InvalidRingMember`).
+* **Duplicate members** are rejected (`DuplicateRingMember`) — they would shrink
+  the effective anonymity set.
+* **Anti-replay.** The statement `m` is opaque and should bind the action
+  context (e.g. `product_id ‖ from ‖ to ‖ nonce`) so a valid attestation cannot
+  be replayed for a different handover. The verifier is otherwise stateless.
+* **Generator integrity.** The hardcoded generator is validated against the host
+  (`generator_is_valid` test) and against both SDKs' independent generators
+  (`generator_matches_contract_constant`, `test_generator_*`).
+* **RNG.** Signing requires a CSPRNG for `α` and the decoy responses. The Rust
+  SDK takes any `RngCore` (use `OsRng`); the Python SDK uses `secrets`. A
+  predictable nonce leaks the secret key, exactly as in Schnorr/EdDSA.
+* The pure-Python G1 arithmetic is **not constant-time** — acceptable for
+  attestation signing, but do not repurpose it for high-frequency secret-key
+  operations under a timing adversary.
+
+---
+
+## 8. Cross-implementation verification
+
+All three implementations are proven to agree on a single **known-answer test
+vector** emitted by the trusted on-chain primitive
+(`emit_sdk_test_vector` in the contract test suite):
+
+| Implementation | Test | Result |
+|----------------|------|--------|
+| Soroban contract | `cargo test -p chainlogistics ring_signature` | 16 passing |
+| Rust SDK | `cargo test --features ring-signatures ring_signature` (incl. `verifies_contract_test_vector`, `generator_matches_contract_constant`) | 7 passing |
+| Python SDK | `pytest sdk/python/tests/test_ring_signature.py` (incl. `test_verifies_contract_test_vector`) | passing |
+
+Because the vector is produced on-chain and accepted by both SDKs' independent
+verifiers (zkcrypto `bls12_381` in Rust; pure-Python G1 in Python), the
+serialization and scalar reduction are guaranteed identical across all three —
+i.e. **a signature produced by either SDK verifies on-chain unchanged.**
+
+---
+
+## 9. Deployment
+
+`AuditTrailContract` and `RingSignatureVerifier` follow the same modular pattern
+as `state_channel` / `oracle`: compiled host-side for the full test suite and
+gated out of the main `ChainLogisticsContract` WASM artifact to avoid export
+symbol collisions. To deploy either as its own contract, build it as a dedicated
+WASM target and `init` the audit trail with the main contract address.

--- a/smart-contract/contracts/src/error.rs
+++ b/smart-contract/contracts/src/error.rs
@@ -124,4 +124,15 @@ pub enum Error {
     DisputePeriodExpired = 139,
     NotChannelParticipant = 140,
     InvalidSignature = 141,
+
+    // --- Ring Signature / Privacy Audit Trail (150-160) ---
+    RingTooSmall = 150,
+    RingTooLarge = 151,
+    RingSizeMismatch = 152,
+    InvalidRingMember = 153,
+    DuplicateRingMember = 154,
+    RingSignatureInvalid = 155,
+    AuditTrailNotInitialized = 156,
+    // Reserved for the linkable (LSAG) variant; see RING_SIGNATURE.md §5.
+    KeyImageAlreadyUsed = 157,
 }

--- a/smart-contract/contracts/src/lib.rs
+++ b/smart-contract/contracts/src/lib.rs
@@ -47,6 +47,8 @@ mod product_registry;
 #[cfg(not(target_arch = "wasm32"))]
 mod product_transfer;
 #[cfg(not(target_arch = "wasm32"))]
+mod ring_signature;
+#[cfg(not(target_arch = "wasm32"))]
 mod state_channel;
 #[cfg(not(target_arch = "wasm32"))]
 mod stats;
@@ -101,6 +103,8 @@ pub use product_query::*;
 pub use product_registry::*;
 #[cfg(not(target_arch = "wasm32"))]
 pub use product_transfer::*;
+#[cfg(not(target_arch = "wasm32"))]
+pub use ring_signature::*;
 #[cfg(not(target_arch = "wasm32"))]
 pub use state_channel::*;
 #[cfg(not(target_arch = "wasm32"))]

--- a/smart-contract/contracts/src/ring_signature.rs
+++ b/smart-contract/contracts/src/ring_signature.rs
@@ -1,0 +1,334 @@
+//! AOS/SAG ring signatures over BLS12-381 G1 for anonymous auditor
+//! attestations. A signature proves the signer is one of the ring's members
+//! without revealing which. Scheme, wire format and design rationale live in
+//! `RING_SIGNATURE.md`; the SDKs and the test signer below must stay byte-for-
+//! byte compatible with the verification here.
+
+#![allow(clippy::too_many_arguments)]
+
+use soroban_sdk::crypto::bls12_381::{Bls12381G1Affine as G1, Fr};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, Address, Bytes, BytesN, Env, String, Vec,
+};
+
+use crate::error::Error;
+use crate::ChainLogisticsContractClient;
+
+const DST_CHALLENGE: &[u8] = b"CHAINLOGISTICS-RINGSIG-V1-CHALLENGE";
+const DST_RING: &[u8] = b"CHAINLOGISTICS-RINGSIG-V1-RING";
+
+/// A ring of one is a deanonymized Schnorr signature, so reject it.
+pub const MIN_RING_SIZE: u32 = 2;
+/// Verification cost is linear in ring size; cap it to bound the per-call gas.
+pub const MAX_RING_SIZE: u32 = 32;
+
+/// Standard BLS12-381 G1 generator, uncompressed (`x ‖ y`, 48 bytes each,
+/// big-endian). Shared by every BLS library, which is what lets off-chain
+/// signers and this verifier agree. Validated by `tests::generator_is_valid`.
+const G1_GENERATOR: [u8; 96] = [
+    // x
+    0x17, 0xf1, 0xd3, 0xa7, 0x31, 0x97, 0xd7, 0x94, 0x26, 0x95, 0x63, 0x8c, 0x4f, 0xa9, 0xac, 0x0f,
+    0xc3, 0x68, 0x8c, 0x4f, 0x97, 0x74, 0xb9, 0x05, 0xa1, 0x4e, 0x3a, 0x3f, 0x17, 0x1b, 0xac, 0x58,
+    0x6c, 0x55, 0xe8, 0x3f, 0xf9, 0x7a, 0x1a, 0xef, 0xfb, 0x3a, 0xf0, 0x0a, 0xdb, 0x22, 0xc6, 0xbb,
+    // y
+    0x08, 0xb3, 0xf4, 0x81, 0xe3, 0xaa, 0xa0, 0xf1, 0xa0, 0x9e, 0x30, 0xed, 0x74, 0x1d, 0x8a, 0xe4,
+    0xfc, 0xf5, 0xe0, 0x95, 0xd5, 0xd0, 0x0a, 0xf6, 0x00, 0xdb, 0x18, 0xcb, 0x2c, 0x04, 0xb3, 0xed,
+    0xd0, 0x3c, 0xc7, 0x44, 0xa2, 0x88, 0x8a, 0xe4, 0x0c, 0xaa, 0x23, 0x29, 0x46, 0xc5, 0xe7, 0xe1,
+];
+
+/// `c0` and each `s` are 32-byte big-endian canonical `F_r` scalars; `s` has
+/// one entry per ring member, in ring order.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RingSignature {
+    pub c0: BytesN<32>,
+    pub s: Vec<BytesN<32>>,
+}
+
+/// An anonymous handover attestation. Carries no signer identity — only the
+/// anonymity set commitment, the product and the statement hash.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HandoverRecord {
+    pub record_id: u64,
+    pub product_id: String,
+    pub ring_commitment: BytesN<32>,
+    pub ring_size: u32,
+    pub statement_hash: BytesN<32>,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+enum AuditKey {
+    MainContract,
+    RecordSeq,
+    Record(u64),
+    ProductRecords(String),
+}
+
+// ─── Events ───────────────────────────────────────────────────────────────
+
+#[soroban_sdk::contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PrivacyHandoverRecorded {
+    pub record_id: u64,
+    pub product_id: String,
+    pub ring_commitment: BytesN<32>,
+    pub ring_size: u32,
+    pub statement_hash: BytesN<32>,
+}
+
+// ─── Core cryptography (shared by both contracts and the tests) ─────────────
+
+fn generator(env: &Env) -> G1 {
+    G1::from_array(env, &G1_GENERATOR)
+}
+
+/// `SHA256(DST_RING ‖ n ‖ P_0 ‖ … ‖ P_{n-1})`. `n` is included so rings whose
+/// member concatenations would otherwise collide stay distinct.
+fn ring_commitment(env: &Env, ring: &Vec<BytesN<96>>) -> BytesN<32> {
+    let mut buf = Bytes::new(env);
+    buf.extend_from_slice(DST_RING);
+    buf.extend_from_array(&ring.len().to_be_bytes());
+    for member in ring.iter() {
+        buf.extend_from_array(&member.to_array());
+    }
+    env.crypto().sha256(&buf).to_bytes()
+}
+
+/// Fiat–Shamir challenge in `F_r`. `Fr::from_bytes` reduces the big-endian
+/// digest mod `r`; the SDKs mirror this as `int.from_bytes(digest,'big') % r`.
+fn challenge(env: &Env, commit: &BytesN<32>, msg_digest: &BytesN<32>, l: &G1) -> Fr {
+    let mut buf = Bytes::new(env);
+    buf.extend_from_slice(DST_CHALLENGE);
+    buf.extend_from_array(&commit.to_array());
+    buf.extend_from_array(&msg_digest.to_array());
+    buf.extend_from_array(&l.to_array());
+    Fr::from_bytes(env.crypto().sha256(&buf).to_bytes())
+}
+
+fn check_ring(env: &Env, ring: &Vec<BytesN<96>>, sig: &RingSignature) -> Result<(), Error> {
+    let n = ring.len();
+    if n < MIN_RING_SIZE {
+        return Err(Error::RingTooSmall);
+    }
+    if n > MAX_RING_SIZE {
+        return Err(Error::RingTooLarge);
+    }
+    if sig.s.len() != n {
+        return Err(Error::RingSizeMismatch);
+    }
+    let bls = env.crypto().bls12_381();
+    for i in 0..n {
+        let member = ring.get(i).unwrap();
+        // Duplicates shrink the effective anonymity set.
+        for j in (i + 1)..n {
+            if member == ring.get(j).unwrap() {
+                return Err(Error::DuplicateRingMember);
+            }
+        }
+        let pk = G1::from_bytes(member);
+        // Soundness-critical: rejects small-subgroup / invalid-curve points.
+        if !bls.g1_is_in_subgroup(&pk) {
+            return Err(Error::InvalidRingMember);
+        }
+    }
+    Ok(())
+}
+
+/// Returns `Ok(())` if `sig` is a valid ring signature over `message` for
+/// `ring`, else the specific rejection reason. Read-only.
+pub fn verify_ring_signature(
+    env: &Env,
+    ring: &Vec<BytesN<96>>,
+    message: &Bytes,
+    sig: &RingSignature,
+) -> Result<(), Error> {
+    check_ring(env, ring, sig)?;
+
+    let bls = env.crypto().bls12_381();
+    let g = generator(env);
+    let commit = ring_commitment(env, ring);
+    let msg_digest = env.crypto().sha256(message).to_bytes();
+
+    let c0 = Fr::from_bytes(sig.c0.clone());
+    let mut c = c0.clone();
+    for i in 0..ring.len() {
+        let pk = G1::from_bytes(ring.get(i).unwrap());
+        let si = Fr::from_bytes(sig.s.get(i).unwrap());
+        // L_i = s_i · G + c · P_i
+        let l = bls.g1_add(&bls.g1_mul(&g, &si), &bls.g1_mul(&pk, &c));
+        c = challenge(env, &commit, &msg_digest, &l);
+    }
+
+    if c == c0 {
+        Ok(())
+    } else {
+        Err(Error::RingSignatureInvalid)
+    }
+}
+
+// ─── Stateless verifier contract ────────────────────────────────────────────
+
+/// Stateless ring-signature verification gateway.
+#[contract]
+pub struct RingSignatureVerifier;
+
+#[contractimpl]
+impl RingSignatureVerifier {
+    /// `true` iff `sig` was produced by a holder of one of the `ring` keys over
+    /// `message`. Returns `false` for invalid signatures; traps only on
+    /// malformed point encodings.
+    pub fn verify(env: Env, ring: Vec<BytesN<96>>, message: Bytes, sig: RingSignature) -> bool {
+        verify_ring_signature(&env, &ring, &message, &sig).is_ok()
+    }
+
+    /// Like [`Self::verify`] but returns the rejection reason. Named
+    /// `verify_strict` because the client reserves `try_verify`.
+    pub fn verify_strict(
+        env: Env,
+        ring: Vec<BytesN<96>>,
+        message: Bytes,
+        sig: RingSignature,
+    ) -> Result<(), Error> {
+        verify_ring_signature(&env, &ring, &message, &sig)
+    }
+
+    /// Canonical ring commitment binding a signature to its anonymity set.
+    pub fn aggregate_ring(env: Env, ring: Vec<BytesN<96>>) -> BytesN<32> {
+        ring_commitment(&env, &ring)
+    }
+
+    /// The generator signers must use, so clients can assert parameter parity.
+    pub fn generator(env: Env) -> BytesN<96> {
+        BytesN::from_array(&env, &G1_GENERATOR)
+    }
+}
+
+// ─── Privacy audit-trail contract ───────────────────────────────────────────
+
+fn get_main_contract(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&AuditKey::MainContract)
+}
+
+fn require_init(env: &Env) -> Result<(), Error> {
+    if get_main_contract(env).is_none() {
+        return Err(Error::AuditTrailNotInitialized);
+    }
+    Ok(())
+}
+
+fn require_not_paused(env: &Env) -> Result<(), Error> {
+    let main = get_main_contract(env).ok_or(Error::AuditTrailNotInitialized)?;
+    if ChainLogisticsContractClient::new(env, &main).is_paused() {
+        return Err(Error::ContractPaused);
+    }
+    Ok(())
+}
+
+fn next_record_id(env: &Env) -> Result<u64, Error> {
+    let current: u64 = env
+        .storage()
+        .persistent()
+        .get(&AuditKey::RecordSeq)
+        .unwrap_or(0);
+    let next = current.checked_add(1).ok_or(Error::ArithmeticOverflow)?;
+    env.storage().persistent().set(&AuditKey::RecordSeq, &next);
+    Ok(next)
+}
+
+/// Records anonymous, ring-signed handover attestations. No signer identity is
+/// ever stored or emitted — only the ring commitment, ring size and statement
+/// hash.
+#[contract]
+pub struct AuditTrailContract;
+
+#[contractimpl]
+impl AuditTrailContract {
+    /// Wire in the main contract address (for the global pause). Callable once.
+    pub fn init(env: Env, main_contract: Address) -> Result<(), Error> {
+        if get_main_contract(&env).is_some() {
+            return Err(Error::AlreadyInitialized);
+        }
+        env.storage()
+            .instance()
+            .set(&AuditKey::MainContract, &main_contract);
+        Ok(())
+    }
+
+    /// Verify a ring signature over `statement` and, on success, store an
+    /// anonymous [`HandoverRecord`] and emit [`PrivacyHandoverRecorded`].
+    /// `statement` is an opaque caller-defined message (bind the action context
+    /// into it, e.g. `product_id ‖ from ‖ to ‖ nonce`). Returns the record id.
+    pub fn record_handover(
+        env: Env,
+        product_id: String,
+        ring: Vec<BytesN<96>>,
+        statement: Bytes,
+        sig: RingSignature,
+    ) -> Result<u64, Error> {
+        require_init(&env)?;
+        require_not_paused(&env)?;
+
+        verify_ring_signature(&env, &ring, &statement, &sig)?;
+
+        let record_id = next_record_id(&env)?;
+        let record = HandoverRecord {
+            record_id,
+            product_id: product_id.clone(),
+            ring_commitment: ring_commitment(&env, &ring),
+            ring_size: ring.len(),
+            statement_hash: env.crypto().sha256(&statement).to_bytes(),
+            timestamp: env.ledger().timestamp(),
+        };
+
+        env.storage()
+            .persistent()
+            .set(&AuditKey::Record(record_id), &record);
+
+        let key = AuditKey::ProductRecords(product_id.clone());
+        let mut ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(&env));
+        ids.push_back(record_id);
+        env.storage().persistent().set(&key, &ids);
+
+        PrivacyHandoverRecorded {
+            record_id,
+            product_id,
+            ring_commitment: record.ring_commitment.clone(),
+            ring_size: record.ring_size,
+            statement_hash: record.statement_hash.clone(),
+        }
+        .publish(&env);
+
+        Ok(record_id)
+    }
+
+    /// Fetch a recorded handover by id.
+    pub fn get_handover(env: Env, record_id: u64) -> Option<HandoverRecord> {
+        env.storage().persistent().get(&AuditKey::Record(record_id))
+    }
+
+    /// List the handover record ids attached to a product.
+    pub fn product_handovers(env: Env, product_id: String) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&AuditKey::ProductRecords(product_id))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Total number of handovers recorded so far.
+    pub fn total_handovers(env: Env) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&AuditKey::RecordSeq)
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/smart-contract/contracts/src/ring_signature/tests.rs
+++ b/smart-contract/contracts/src/ring_signature/tests.rs
@@ -1,0 +1,438 @@
+//! Tests for the ring-signature verifier and the privacy audit trail. [`sign`]
+//! is the reference signer the SDKs mirror; it uses the same host functions as
+//! the verifier, so both agree bit-for-bit and the on-chain `verify` is an
+//! oracle for the SDK signers (cross-checked via `emit_sdk_test_vector`).
+
+extern crate std;
+
+use super::*;
+use crate::{ChainLogisticsContract, ChainLogisticsContractClient};
+use soroban_sdk::{
+    testutils::Address as _,
+    Address, Bytes, BytesN, Env, String, Vec,
+};
+
+// ─── Reference signer (mirrors the SDKs) ────────────────────────────────────
+
+// Deterministic seeds keep test failures reproducible; the verifier only needs
+// each value to be a valid F_r scalar.
+fn fr_from_seed(env: &Env, tag: &[u8], i: u32) -> Fr {
+    let mut b = Bytes::new(env);
+    b.extend_from_slice(tag);
+    b.extend_from_array(&i.to_be_bytes());
+    Fr::from_bytes(env.crypto().sha256(&b).to_bytes())
+}
+
+fn keypair(env: &Env, i: u32) -> (Fr, BytesN<96>) {
+    let x = fr_from_seed(env, b"chainlogistics-sk", i);
+    let p = env.crypto().bls12_381().g1_mul(&generator(env), &x);
+    (x, p.to_bytes())
+}
+
+fn build_ring(env: &Env, n: u32, signer_index: u32) -> (Vec<BytesN<96>>, Fr) {
+    let mut ring = Vec::new(env);
+    let mut secret = fr_from_seed(env, b"placeholder", 0);
+    for i in 0..n {
+        let (x, p) = keypair(env, i);
+        if i == signer_index {
+            secret = x;
+        }
+        ring.push_back(p);
+    }
+    (ring, secret)
+}
+
+/// Produce a ring signature over `message` as ring member `signer_index`.
+// Produce a ring signature over `message` as ring member `signer_index`.
+fn sign(
+    env: &Env,
+    ring: &Vec<BytesN<96>>,
+    signer_index: u32,
+    secret: &Fr,
+    message: &Bytes,
+) -> RingSignature {
+    let n = ring.len();
+    let bls = env.crypto().bls12_381();
+    let g = generator(env);
+    let commit = ring_commitment(env, ring);
+    let md = env.crypto().sha256(message).to_bytes();
+
+    let zero = BytesN::from_array(env, &[0u8; 32]);
+    let mut c_arr: Vec<BytesN<32>> = Vec::new(env);
+    let mut s_arr: Vec<BytesN<32>> = Vec::new(env);
+    for _ in 0..n {
+        c_arr.push_back(zero.clone());
+        s_arr.push_back(zero.clone());
+    }
+
+    // Seed the chain at the signer's index with a random nonce α.
+    let alpha = fr_from_seed(env, b"chainlogistics-alpha", signer_index);
+    let l_pi = bls.g1_mul(&g, &alpha);
+    c_arr.set(
+        (signer_index + 1) % n,
+        challenge(env, &commit, &md, &l_pi).to_bytes(),
+    );
+
+    // Walk the remaining ring members with random decoy responses.
+    for j in 1..n {
+        let idx = (signer_index + j) % n;
+        let s_idx = fr_from_seed(env, b"chainlogistics-decoy", idx);
+        s_arr.set(idx, s_idx.to_bytes());
+
+        let c_idx = Fr::from_bytes(c_arr.get(idx).unwrap());
+        let pk = G1::from_bytes(ring.get(idx).unwrap());
+        let l = bls.g1_add(&bls.g1_mul(&g, &s_idx), &bls.g1_mul(&pk, &c_idx));
+        c_arr.set((idx + 1) % n, challenge(env, &commit, &md, &l).to_bytes());
+    }
+
+    // Close the ring: s_π = α − c_π · x  (mod r).
+    let c_pi = Fr::from_bytes(c_arr.get(signer_index).unwrap());
+    let s_pi = alpha - (c_pi * secret.clone());
+    s_arr.set(signer_index, s_pi.to_bytes());
+
+    RingSignature {
+        c0: c_arr.get(0).unwrap(),
+        s: s_arr,
+    }
+}
+
+fn msg(env: &Env, bytes: &[u8]) -> Bytes {
+    Bytes::from_slice(env, bytes)
+}
+
+fn hex32(b: &BytesN<32>) -> std::string::String {
+    let mut s = std::string::String::new();
+    for byte in b.to_array().iter() {
+        s.push_str(&std::format!("{byte:02x}"));
+    }
+    s
+}
+
+fn hex96(b: &BytesN<96>) -> std::string::String {
+    let mut s = std::string::String::new();
+    for byte in b.to_array().iter() {
+        s.push_str(&std::format!("{byte:02x}"));
+    }
+    s
+}
+
+// Emits the known-answer vector the SDK test suites embed. An SDK `verify`
+// accepting this chain-produced signature proves bit-for-bit agreement.
+// Run: `cargo test emit_sdk_test_vector -- --nocapture`.
+#[test]
+fn emit_sdk_test_vector() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+    let n = 3u32;
+    let signer = 1u32;
+    let message = msg(&env, b"handover: PROD-7 alice->bob nonce=42");
+    let (ring, secret) = build_ring(&env, n, signer);
+    let sig = sign(&env, &ring, signer, &secret, &message);
+    assert_eq!(verify_ring_signature(&env, &ring, &message, &sig), Ok(()));
+
+    std::eprintln!("--- BEGIN RING SIGNATURE TEST VECTOR ---");
+    std::eprintln!("message_utf8=handover: PROD-7 alice->bob nonce=42");
+    for i in 0..n {
+        std::eprintln!("ring[{i}]={}", hex96(&ring.get(i).unwrap()));
+    }
+    std::eprintln!("c0={}", hex32(&sig.c0));
+    for i in 0..n {
+        std::eprintln!("s[{i}]={}", hex32(&sig.s.get(i).unwrap()));
+    }
+    std::eprintln!("ring_commitment={}", hex32(&ring_commitment(&env, &ring)));
+    std::eprintln!("--- END RING SIGNATURE TEST VECTOR ---");
+}
+
+// ─── Pure-crypto tests ──────────────────────────────────────────────────────
+
+#[test]
+fn generator_is_valid() {
+    let env = Env::default();
+    let bls = env.crypto().bls12_381();
+    let g = generator(&env);
+    // Subgroup membership implies on-curve, validating the generator constant.
+    assert!(
+        bls.g1_is_in_subgroup(&g),
+        "hardcoded G1 generator must be in the prime-order subgroup"
+    );
+}
+
+#[test]
+fn sign_and_verify_round_trip_all_indices() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+    let n = 5u32;
+    let message = msg(&env, b"handover: product-42 from alice to bob");
+    for signer in 0..n {
+        let (ring, secret) = build_ring(&env, n, signer);
+        let sig = sign(&env, &ring, signer, &secret, &message);
+        assert_eq!(
+            verify_ring_signature(&env, &ring, &message, &sig),
+            Ok(()),
+            "valid signature from index {signer} must verify"
+        );
+    }
+}
+
+#[test]
+fn verify_various_ring_sizes() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+    let message = msg(&env, b"audit attestation");
+    for &n in &[2u32, 3, 4, 8, 16] {
+        let signer = n / 2;
+        let (ring, secret) = build_ring(&env, n, signer);
+        let sig = sign(&env, &ring, signer, &secret, &message);
+        assert_eq!(verify_ring_signature(&env, &ring, &message, &sig), Ok(()));
+    }
+}
+
+#[test]
+fn wrong_message_is_rejected() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+    let (ring, secret) = build_ring(&env, 4, 1);
+    let sig = sign(&env, &ring, 1, &secret, &msg(&env, b"original statement"));
+    assert_eq!(
+        verify_ring_signature(&env, &ring, &msg(&env, b"tampered statement"), &sig),
+        Err(Error::RingSignatureInvalid)
+    );
+}
+
+#[test]
+fn tampered_response_is_rejected() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+    let message = msg(&env, b"statement");
+    let (ring, secret) = build_ring(&env, 4, 2);
+    let mut sig = sign(&env, &ring, 2, &secret, &message);
+    // Flip one response scalar.
+    sig.s.set(0, BytesN::from_array(&env, &[7u8; 32]));
+    assert_eq!(
+        verify_ring_signature(&env, &ring, &message, &sig),
+        Err(Error::RingSignatureInvalid)
+    );
+}
+
+#[test]
+fn signature_does_not_verify_against_a_different_ring() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+    let message = msg(&env, b"statement");
+    let (ring, secret) = build_ring(&env, 4, 0);
+    let sig = sign(&env, &ring, 0, &secret, &message);
+
+    // Replace one decoy member with an unrelated key: the ring commitment
+    // changes, so the bound signature must fail.
+    let mut other = ring.clone();
+    let (_x, p) = keypair(&env, 999);
+    other.set(3, p);
+    assert_eq!(
+        verify_ring_signature(&env, &other, &message, &sig),
+        Err(Error::RingSignatureInvalid)
+    );
+}
+
+#[test]
+fn non_member_cannot_forge() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+    let message = msg(&env, b"statement");
+    // Ring of members 0..4; the attacker holds key 50, which is NOT in the ring.
+    let (ring, _secret) = build_ring(&env, 4, 0);
+    let (outsider_sk, outsider_pk) = keypair(&env, 50);
+    assert!(!ring.contains(&outsider_pk));
+    // Attacker signs as if they were index 0 with their own (wrong) secret.
+    let forged = sign(&env, &ring, 0, &outsider_sk, &message);
+    assert_eq!(
+        verify_ring_signature(&env, &ring, &message, &forged),
+        Err(Error::RingSignatureInvalid)
+    );
+}
+
+#[test]
+fn ring_too_small_is_rejected() {
+    let env = Env::default();
+    let (ring, secret) = build_ring(&env, 1, 0);
+    let sig = sign(&env, &ring, 0, &secret, &msg(&env, b"x"));
+    assert_eq!(
+        verify_ring_signature(&env, &ring, &msg(&env, b"x"), &sig),
+        Err(Error::RingTooSmall)
+    );
+}
+
+#[test]
+fn ring_size_mismatch_is_rejected() {
+    let env = Env::default();
+    let (ring, secret) = build_ring(&env, 3, 0);
+    let mut sig = sign(&env, &ring, 0, &secret, &msg(&env, b"x"));
+    sig.s.pop_back(); // now len 2 != ring len 3
+    assert_eq!(
+        verify_ring_signature(&env, &ring, &msg(&env, b"x"), &sig),
+        Err(Error::RingSizeMismatch)
+    );
+}
+
+#[test]
+fn duplicate_member_is_rejected() {
+    let env = Env::default();
+    let (ring, secret) = build_ring(&env, 3, 0);
+    let mut dup = ring.clone();
+    dup.set(2, ring.get(0).unwrap()); // member 0 appears twice
+    let sig = sign(&env, &ring, 0, &secret, &msg(&env, b"x"));
+    assert_eq!(
+        verify_ring_signature(&env, &dup, &msg(&env, b"x"), &sig),
+        Err(Error::DuplicateRingMember)
+    );
+}
+
+#[test]
+fn aggregate_ring_is_deterministic_and_order_sensitive() {
+    let env = Env::default();
+    let (ring, _) = build_ring(&env, 4, 0);
+    let c1 = ring_commitment(&env, &ring);
+    let c2 = ring_commitment(&env, &ring);
+    assert_eq!(c1, c2, "commitment must be deterministic");
+
+    let mut reordered = Vec::new(&env);
+    reordered.push_back(ring.get(1).unwrap());
+    reordered.push_back(ring.get(0).unwrap());
+    reordered.push_back(ring.get(2).unwrap());
+    reordered.push_back(ring.get(3).unwrap());
+    assert_ne!(
+        c1,
+        ring_commitment(&env, &reordered),
+        "commitment must depend on member order"
+    );
+}
+
+// ─── Verifier contract tests ────────────────────────────────────────────────
+
+#[test]
+fn verifier_contract_accepts_valid_and_rejects_invalid() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+    let id = env.register_contract(None, RingSignatureVerifier);
+    let client = RingSignatureVerifierClient::new(&env, &id);
+
+    let message = msg(&env, b"handover statement");
+    let (ring, secret) = build_ring(&env, 6, 3);
+    let sig = sign(&env, &ring, 3, &secret, &message);
+
+    assert!(client.verify(&ring, &message, &sig));
+    assert!(!client.verify(&ring, &msg(&env, b"other"), &sig));
+    assert_eq!(client.aggregate_ring(&ring), ring_commitment(&env, &ring));
+    assert_eq!(client.generator(), BytesN::from_array(&env, &G1_GENERATOR));
+}
+
+// ─── Audit-trail contract tests ─────────────────────────────────────────────
+
+fn setup_audit(
+    env: &Env,
+) -> (
+    AuditTrailContractClient<'static>,
+    ChainLogisticsContractClient<'static>,
+    Address,
+) {
+    env.mock_all_auths();
+    let cl_id = env.register_contract(None, ChainLogisticsContract);
+    let at_id = env.register_contract(None, AuditTrailContract);
+    let cl = ChainLogisticsContractClient::new(env, &cl_id);
+    let at = AuditTrailContractClient::new(env, &at_id);
+
+    let admin = Address::generate(env);
+    let auth_contract = Address::generate(env);
+    cl.init(&admin, &auth_contract);
+    at.init(&cl_id);
+    (at, cl, admin)
+}
+
+#[test]
+fn record_handover_stores_anonymous_record() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+    let (at, _cl, _admin) = setup_audit(&env);
+
+    let product_id = String::from_str(&env, "PROD-001");
+    let statement = msg(&env, b"custody: warehouse-A -> truck-7");
+    let (ring, secret) = build_ring(&env, 5, 2);
+    let sig = sign(&env, &ring, 2, &secret, &statement);
+
+    let record_id = at.record_handover(&product_id, &ring, &statement, &sig);
+    assert_eq!(record_id, 1);
+    assert_eq!(at.total_handovers(), 1);
+
+    let record = at.get_handover(&record_id).unwrap();
+    assert_eq!(record.product_id, product_id);
+    assert_eq!(record.ring_size, 5);
+    assert_eq!(record.ring_commitment, ring_commitment(&env, &ring));
+    assert_eq!(record.statement_hash, env.crypto().sha256(&statement).to_bytes());
+
+    let ids = at.product_handovers(&product_id);
+    assert_eq!(ids.len(), 1);
+    assert_eq!(ids.get(0).unwrap(), 1);
+}
+
+#[test]
+fn record_handover_rejects_invalid_signature() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+    let (at, _cl, _admin) = setup_audit(&env);
+
+    let product_id = String::from_str(&env, "PROD-002");
+    let statement = msg(&env, b"custody change");
+    let (ring, secret) = build_ring(&env, 4, 1);
+    let mut sig = sign(&env, &ring, 1, &secret, &statement);
+    sig.c0 = BytesN::from_array(&env, &[1u8; 32]); // corrupt seed challenge
+
+    let res = at.try_record_handover(&product_id, &ring, &statement, &sig);
+    assert_eq!(res, Err(Ok(Error::RingSignatureInvalid)));
+    assert_eq!(at.total_handovers(), 0);
+}
+
+#[test]
+fn record_handover_respects_global_pause() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+    let (at, cl, admin) = setup_audit(&env);
+
+    // Pause the main contract; admin auth is mocked.
+    cl.pause(&admin);
+
+    let product_id = String::from_str(&env, "PROD-003");
+    let statement = msg(&env, b"statement");
+    let (ring, secret) = build_ring(&env, 3, 0);
+    let sig = sign(&env, &ring, 0, &secret, &statement);
+
+    let res = at.try_record_handover(&product_id, &ring, &statement, &sig);
+    assert_eq!(res, Err(Ok(Error::ContractPaused)));
+}
+
+// ─── Gas / cost documentation ───────────────────────────────────────────────
+
+// Prints the per-ring-size cost table in RING_SIGNATURE.md. Measured under an
+// unlimited budget because native estimates underestimate the WASM equivalent,
+// so the real per-tx limit is validated on testnet, not here.
+// Run: `cargo test ring_signature -- --nocapture`.
+#[test]
+fn gas_costs_across_ring_sizes() {
+    let env = Env::default();
+    let id = env.register_contract(None, RingSignatureVerifier);
+    let client = RingSignatureVerifierClient::new(&env, &id);
+    let message = msg(&env, b"handover statement");
+
+    for &n in &[2u32, 4, 8, 16, 32] {
+        let signer = n / 2;
+        let (ring, secret) = build_ring(&env, n, signer);
+        let sig = sign(&env, &ring, signer, &secret, &message);
+
+        env.budget().reset_unlimited();
+        let ok = client.verify(&ring, &message, &sig);
+        let cpu = env.budget().cpu_instruction_cost();
+        let mem = env.budget().memory_bytes_cost();
+        assert!(ok);
+        // Loose ceiling to catch a super-linear regression.
+        assert!(cpu < 12_000_000 * (n as u64), "ring size {n}: cpu {cpu}");
+        std::eprintln!("ring_size={n} cpu_insns={cpu} mem_bytes={mem}");
+    }
+}


### PR DESCRIPTION
## Description

Implements a privacy-preserving audit trail using **AOS/SAG ring signatures over BLS12-381 G1**, so auditors can attest to supply-chain handovers as an anonymous member of a ring — any verifier confirms the signer is *one of* the ring, but not *which* one. This protects auditors from bribery, coercion and retaliation.

Delivers the three components from the issue — an on-chain ring-signature **verifier in Soroban**, **signing logic in the Rust and Python SDKs**, and **public-key (ring) aggregation** — plus an `AuditTrailContract` that records anonymous handovers, and documentation answering the issue's design questions (gas feasibility, linkability) with measured costs.

The scheme uses only host functions available today (CAP-0059: `g1_mul`, `g1_add`, `g1_is_in_subgroup`, `sha256`) and **no pairings**, so verification is materially cheaper than a SNARK.

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] 🔧 Code refactor (no functional changes)
  - [x] 📚 Documentation update
  - [x] 🧪 Tests (adding or updating tests)
  - [x] 🔒 Security (security-related changes)
  - [ ] 🚀 Performance (performance-related changes)
  - [ ] 🎨 UI/UX (user interface changes)
  - [ ] 🛠️  DevOps (deployment, CI/CD, infrastructure changes)

  ## Changes Made

  ### Code Changes

  **Smart contract (`smart-contract/contracts/src/`)**
  - `ring_signature.rs` — new module:
  - `RingSignatureVerifier` (stateless gateway): `verify`, `verify_strict`, `aggregate_ring` (public-key aggregation → canonical ring commitment), `generator`.
  - `AuditTrailContract` (stateful): `record_handover` verifies the ring signature and stores an **anonymous** `HandoverRecord` (no signer identity, no relayer identity) + emits `PrivacyHandoverRecorded`; honors the main contract's global pause. Plus getters (`get_handover`, `product_handovers`, `total_handovers`).
  - Subgroup checks on every ring member; duplicate-member rejection.
  - `error.rs` — 8 new error variants (`150–157`); `157` reserved for the future linkable (LSAG) variant.
  - `lib.rs` — module wired in, gated to host-side builds like `state_channel`/`oracle` (kept out of the main `ChainLogisticsContract` WASM to avoid export-symbol collisions).

  **Rust SDK (`sdk/rust/`)** — `ring_signature.rs` behind an optional `ring-signatures` feature (zkcrypto `bls12_381`, `sha2`, `rand_core`). `KeyPair`, `sign`, `verify`, `aggregate_ring` in the contract's
  exact wire format.

  **Python SDK (`sdk/python/`)** — `ring_signature.py`, **pure standard library / zero new dependencies** (self-contained G1 arithmetic, no pairings). Same API and wire format; exported from the package.

  ### Documentation Updates

  - `smart-contract/RING_SIGNATURE.md` — scheme spec, wire format, on-chain/off-chain APIs, **measured gas table**, **linkability analysis** (design question), **short-ring-signature** optimization ideas,
  security notes, cross-implementation verification, and deployment notes.
  - `sdk/rust/README.md` and `sdk/python/README.md` — usage sections.

  ### Database/Schema Changes

  None. (On-chain state only: anonymous `HandoverRecord`s keyed by id and indexed per product.)

  ## Testing

  ### Manual Testing

Generated a canonical known-answer signature on-chain (`emit_sdk_test_vector`) and confirmed both SDK verifiers accept it unchanged, proving byte-for-byte agreement (serialization + scalar reduction) across all three implementations. Captured per-ring-size CPU/memory costs via the contract test host.

  ### Automated Tests

  - **Contract:** 17 tests — round-trip across all signer indices and ring sizes; rejection of wrong message, tampered response, swapped ring, non-member forgery; ring-too-small / size-mismatch / duplicate-member; deterministic & order-sensitive aggregation; verifier-contract and audit-trail flows (incl. global-pause and invalid-signature rejection); gas measurement.
  - **Rust SDK:** 7 tests + doctest — round-trips, negative cases, `generator_matches_contract_constant`, and `verifies_contract_test_vector` (against the contract-produced vector).
  - **Python SDK:** known-answer vector + round-trips + prime-order generator check + negative cases.
  - Full contract host suite re-run: **209 passed, 0 failed**.

  - [x] Unit tests pass
  - [x] Integration tests pass <!-- audit-trail ↔ main-contract cross-contract pause flow -->
  - [ ] E2E tests pass (if applicable) <!-- N/A -->
  - [x] Performance tests pass (if applicable) <!-- gas/cost measurement test -->

  ### Test Coverage

Increases coverage: a new module with comprehensive positive, negative, security, and cost tests; cross-implementation parity is asserted against a shared vector.

  ## Breaking Changes

None — all additions are new modules/contracts gated behind features or host-side builds; existing APIs and the main contract WASM are unchanged.

  One incidental, strictly-additive build fix: `sdk/rust/Cargo.toml` enables `tokio`'s `macros` feature so the **pre-existing** `products.rs` `#[tokio::test]` tests compile (they did not on `main`);
  `Cargo.lock` bumps `tokio` 1.50.0 → 1.52.3 accordingly (within `^1.0`).

  ## Checklist

  ### Code Quality
  - [x] Code follows project style guidelines
  - [x] Code is self-documenting or properly commented
  - [x] No console.log statements or debugger breakpoints left
  - [x] No unused imports or variables
  - [x] Code passes linting checks

  ### Testing
  - [x] Unit tests added/updated for new functionality
  - [x] Integration tests added/updated if needed
  - [x] Manual testing completed
  - [x] Edge cases considered and tested
  - [x] Tests pass locally

  ### Documentation
  - [x] README updated if needed
  - [x] API documentation updated if needed
  - [x] Inline code documentation added/updated
  - [x] Comments added for complex logic

  ### Security
  - [x] Security implications reviewed
  - [x] No sensitive data exposed <!-- signer identity is never stored or emitted -->
  - [x] Input validation added where needed <!-- subgroup/curve checks, ring bounds, duplicate rejection -->
  - [x] Authentication/authorization considered <!-- honors the main contract's global pause -->

  ### Performance
  - [x] Performance impact assessed <!-- ~7.5M CPU instructions/ring member; documented gas table -->
  - [x] No performance regressions introduced
  - [ ] Bundle size checked (frontend) <!-- N/A -->
  - [x] Database queries optimized (backend) <!-- N/A; on-chain storage only -->

  ### Deployment
  - [x] Environment variables documented <!-- none introduced -->
  - [ ] Database migrations included <!-- N/A -->
  - [x] Backward compatibility maintained
  - [x] Rollback plan considered <!-- additive contracts; deploy/init independently -->

  ### Legal/Compliance
  - [ ] DCO (Developer Certificate of Origin) signed <!-- sign-off on commit -->
  - [ ] License headers added to new files <!-- repo does not use per-file headers; matches existing convention -->
  - [x] Third-party dependencies reviewed <!-- bls12_381, sha2, rand_core (Rust, optional); Python adds none -->
  - [x] GDPR/privacy implications considered <!-- core goal: signer anonymity; no PII recorded -->

  ## Related Issues

  Closes #413
  Depends on #401

  ## Additional Context

  - **Linkability (design question):** V1 is intentionally **unlinkable** (max anonymity, right default for attestation). A documented **LSAG** upgrade path — key image `I = x · H_p(P)` via the host `hash_to_g1` — enables one-attestation-per-auditor (e.g. anonymous voting) and is staged as V2 once cross-impl hash-to-curve vectors are pinned. Error `KeyImageAlreadyUsed (157)` is reserved for it.
  - **Gas (design question):** verification is linear, ≈ **7.5M CPU instructions / ring member**. Recommended on-chain ring size ≤ 8; hard cap 32 (`MAX_RING_SIZE`). Native estimates underestimate WASM, so large rings should be validated on testnet — see `RING_SIGNATURE.md` for the full table and the short-ring-signature / accumulator route to larger anonymity sets.
  - **Deployment:** `RingSignatureVerifier` and `AuditTrailContract` follow the `state_channel`/`oracle` pattern (host-side for tests, built as dedicated WASM targets for deployment); `init` the audit trail with the main contract address.